### PR TITLE
Build immersive 360 tour creator and viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+public/tours/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# tour360
+# Tour360 Studio
+
+Plataforma minimalista en tonos oscuros que permite crear y compartir tours 360°. Los usuarios pueden subir panorámicas, previsualizarlas, generar hotspots interactivos y guardar el resultado dentro de una carpeta accesible desde `dominio/carpeta`.
+
+## Características
+
+- **Creación de proyectos** con un nombre de carpeta que define la URL pública.
+- **Carga de fotografías 360°** (JPG, PNG o WEBP) con administración de escenas.
+- **Visualizador interactivo** basado en Photo Sphere Viewer.
+- **Hotspots enlazados** entre escenas para recorrer el espacio.
+- **Publicación automática** del tour en `/<carpeta>` para visitantes.
+
+## Requisitos
+
+- Python 3.9 o superior.
+- Acceso a Internet para cargar los assets CDN (Photo Sphere Viewer y fuentes).
+
+## Ejecutar el servidor
+
+```bash
+python3 server.py
+```
+
+El servidor se iniciará en `http://localhost:8000`. La interfaz de edición está disponible en la raíz (`/`).
+
+## Flujo de trabajo
+
+1. En la página principal introduce el nombre de la carpeta (solo letras, números y guiones) y un título opcional.
+2. Sube tus panorámicas 360°; cada escena se puede abrir y visualizar inmediatamente.
+3. Selecciona una escena, pulsa **Añadir hotspot** y haz clic sobre la vista para ubicarlo. Define la etiqueta y la escena destino.
+4. Marca la escena inicial del tour y guarda los cambios.
+5. Comparte el enlace generado (`http://localhost:8000/tu-carpeta`) para que otros recorran el tour.
+
+## Estructura
+
+- `server.py`: servidor HTTP con API para tours y contenido estático.
+- `public/index.html`: interfaz de edición de tours.
+- `public/viewer.html`: visor público para los tours guardados.
+- `public/js`: lógica de la app (constructor y visor).
+- `public/styles.css`: estilos oscuros de inspiración futurista.
+
+Los tours se almacenan en `public/tours/<carpeta>` junto con un archivo `tour.json` que describe escenas y hotspots.
+
+## Notas
+
+- Las imágenes 360° deben estar en formato equirectangular para una visualización correcta.
+- Los hotspots pueden apuntar a cualquier escena existente, incluida la actual.
+- El proyecto no requiere dependencias externas más allá de la biblioteca estándar de Python.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "tour360-studio",
+  "version": "1.0.0",
+  "description": "Constructor minimalista de tours 360° con hotspots interactivos.",
+  "scripts": {
+    "start": "python3 server.py"
+  },
+  "keywords": ["360", "tour", "viewer", "panorama"],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tour360 Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.css"
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="hero">
+        <div>
+          <p class="hero-kicker">Crea experiencias inmersivas</p>
+          <h1>Tour360 Studio</h1>
+          <p class="hero-subtitle">
+            Construye tours 360° minimalistas en minutos. Sube tus escenas,
+            posiciona hotspots y comparte el resultado con una sola URL.
+          </p>
+        </div>
+      </header>
+
+      <section class="creation-panel" id="createPanel">
+        <form id="createTourForm" class="card">
+          <h2>Comienza un nuevo tour</h2>
+          <div class="field">
+            <label for="tourName">Nombre de la carpeta *</label>
+            <input
+              type="text"
+              id="tourName"
+              name="tourName"
+              placeholder="ej. showroom-neon"
+              autocomplete="off"
+              required
+            />
+            <small>
+              Solo letras, números y guiones. Así se verá tu enlace:
+              <span id="slugPreview">tu-dominio/carpeta</span>
+            </small>
+          </div>
+          <div class="field">
+            <label for="tourTitle">Título visible (opcional)</label>
+            <input
+              type="text"
+              id="tourTitle"
+              name="tourTitle"
+              placeholder="Nombre para tus visitantes"
+            />
+          </div>
+          <button class="primary" type="submit">Crear tour</button>
+          <p class="hint">
+            Si el tour ya existe, lo abriremos para seguir editando.
+          </p>
+        </form>
+      </section>
+
+      <section class="workspace hidden" id="workspace">
+        <aside class="sidebar">
+          <div class="sidebar-header">
+            <h2>Escenas 360°</h2>
+            <p class="muted">
+              Sube panorámicas equirectangulares en JPG, PNG o WEBP.
+            </p>
+          </div>
+          <label class="upload-label">
+            <input type="file" id="sceneUpload" accept="image/*" />
+            <span>Subir nueva escena</span>
+          </label>
+          <div class="sidebar-info">
+            <p id="tourFolderInfo"></p>
+            <a
+              id="tourPublicLink"
+              class="tour-link hidden"
+              href="#"
+              target="_blank"
+              rel="noopener"
+            ></a>
+          </div>
+          <ul class="scene-list" id="scenesList"></ul>
+        </aside>
+        <section class="viewer-area">
+          <div class="viewer-header">
+            <div>
+              <h2 id="currentSceneTitle">Selecciona una escena</h2>
+              <p id="viewerHint" class="muted"></p>
+            </div>
+            <div class="viewer-actions">
+              <button class="ghost" type="button" id="addHotspot">
+                Añadir hotspot
+              </button>
+              <button class="primary" type="button" id="saveTour">
+                Guardar tour
+              </button>
+            </div>
+          </div>
+          <div class="viewer-shell">
+            <div id="viewer" class="viewer"></div>
+            <div id="placingNotice" class="placing hidden">
+              Haz clic sobre la escena para posicionar el hotspot
+            </div>
+          </div>
+          <div class="hotspots-panel">
+            <div class="hotspots-head">
+              <h3>Hotspots de la escena</h3>
+              <span id="hotspotCount" class="muted"></span>
+            </div>
+            <ul class="hotspot-list" id="hotspotsList"></ul>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <div class="modal hidden" id="sceneModal" role="dialog" aria-modal="true">
+      <div class="modal-content">
+        <h3>Nombrar escena</h3>
+        <p class="muted" id="sceneFileName"></p>
+        <label class="field">
+          <span>Nombre</span>
+          <input type="text" id="sceneNameInput" placeholder="Vista principal" />
+        </label>
+        <div class="modal-actions">
+          <button class="ghost" type="button" id="cancelSceneModal">Cancelar</button>
+          <button class="primary" type="button" id="confirmSceneModal">Subir escena</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal hidden" id="hotspotModal" role="dialog" aria-modal="true">
+      <div class="modal-content">
+        <h3>Configurar hotspot</h3>
+        <label class="field">
+          <span>Etiqueta</span>
+          <input type="text" id="hotspotLabel" placeholder="Ej. Ir a lobby" />
+        </label>
+        <label class="field">
+          <span>Escena destino</span>
+          <select id="hotspotTarget"></select>
+        </label>
+        <div class="modal-actions">
+          <button class="ghost" type="button" id="cancelHotspot">Cancelar</button>
+          <button class="primary" type="button" id="confirmHotspot">Guardar hotspot</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/uevent@2.0.0/browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.js"></script>
+    <script type="module" src="/js/index.js"></script>
+  </body>
+</html>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,0 +1,611 @@
+const state = {
+  slug: '',
+  title: '',
+  scenes: [],
+  initialSceneId: null,
+  currentSceneId: null,
+};
+
+let viewer = null;
+let markersPlugin = null;
+let placingHotspot = false;
+let pendingCoords = null;
+let pendingSceneFile = null;
+let toastTimeout = null;
+
+const createForm = document.getElementById('createTourForm');
+const createPanel = document.getElementById('createPanel');
+const workspace = document.getElementById('workspace');
+const tourNameInput = document.getElementById('tourName');
+const tourTitleInput = document.getElementById('tourTitle');
+const slugPreview = document.getElementById('slugPreview');
+const sceneUploadInput = document.getElementById('sceneUpload');
+const scenesListEl = document.getElementById('scenesList');
+const viewerTitleEl = document.getElementById('currentSceneTitle');
+const viewerHintEl = document.getElementById('viewerHint');
+const addHotspotBtn = document.getElementById('addHotspot');
+const saveTourBtn = document.getElementById('saveTour');
+const hotspotsListEl = document.getElementById('hotspotsList');
+const hotspotCountEl = document.getElementById('hotspotCount');
+const placingNotice = document.getElementById('placingNotice');
+const hotspotModal = document.getElementById('hotspotModal');
+const hotspotLabelInput = document.getElementById('hotspotLabel');
+const hotspotTargetSelect = document.getElementById('hotspotTarget');
+const confirmHotspotBtn = document.getElementById('confirmHotspot');
+const cancelHotspotBtn = document.getElementById('cancelHotspot');
+const toastEl = document.getElementById('toast');
+const tourFolderInfo = document.getElementById('tourFolderInfo');
+const tourPublicLink = document.getElementById('tourPublicLink');
+const sceneModal = document.getElementById('sceneModal');
+const sceneNameInput = document.getElementById('sceneNameInput');
+const confirmSceneModalBtn = document.getElementById('confirmSceneModal');
+const cancelSceneModalBtn = document.getElementById('cancelSceneModal');
+const sceneFileName = document.getElementById('sceneFileName');
+
+function normalizeOrigin() {
+  return window.location.origin && window.location.origin !== 'null'
+    ? window.location.origin
+    : 'tu-dominio';
+}
+
+function slugify(value) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-\s]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function updateSlugPreview() {
+  const slug = slugify(tourNameInput.value) || 'carpeta';
+  slugPreview.textContent = `${normalizeOrigin()}/${slug}`;
+}
+
+tourNameInput.addEventListener('input', updateSlugPreview);
+
+function showToast(message, type = 'info') {
+  toastEl.textContent = message;
+  toastEl.classList.remove('hidden', 'success', 'error', 'visible');
+  if (type === 'success') {
+    toastEl.classList.add('success');
+  } else if (type === 'error') {
+    toastEl.classList.add('error');
+  }
+  toastEl.classList.add('visible');
+  clearTimeout(toastTimeout);
+  toastTimeout = setTimeout(() => {
+    toastEl.classList.add('hidden');
+    toastEl.classList.remove('visible');
+  }, 3200);
+}
+
+function hideToast() {
+  toastEl.classList.add('hidden');
+  toastEl.classList.remove('visible');
+  clearTimeout(toastTimeout);
+}
+
+function mapScene(scene) {
+  return {
+    id: scene.id,
+    name: scene.name,
+    file: scene.file,
+    hotspots: (scene.hotspots || []).map((spot) => ({
+      id: spot.id,
+      label: spot.label,
+      targetSceneId: spot.targetSceneId || null,
+      yaw: Number(spot.yaw),
+      pitch: Number(spot.pitch),
+    })),
+    url: scene.url || `/tours/${state.slug}/${scene.file}`,
+  };
+}
+
+function getSceneById(id) {
+  return state.scenes.find((scene) => scene.id === id) || null;
+}
+
+function getCurrentScene() {
+  return getSceneById(state.currentSceneId);
+}
+
+function renderScenesList() {
+  if (!state.scenes.length) {
+    scenesListEl.innerHTML = '<li class="scene-empty">Sube tu primera escena 360° para comenzar.</li>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  state.scenes.forEach((scene) => {
+    const li = document.createElement('li');
+    li.className = `scene-item${state.currentSceneId === scene.id ? ' active' : ''}`;
+    li.dataset.id = scene.id;
+
+    const img = document.createElement('img');
+    img.src = scene.url;
+    img.alt = scene.name;
+    img.className = 'scene-thumb';
+    li.appendChild(img);
+
+    const details = document.createElement('div');
+    details.className = 'scene-details';
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'scene-name';
+    nameEl.textContent = scene.name;
+    details.appendChild(nameEl);
+
+    const actions = document.createElement('div');
+    actions.className = 'scene-actions';
+
+    const viewBtn = document.createElement('button');
+    viewBtn.type = 'button';
+    viewBtn.dataset.action = 'view';
+    viewBtn.className = 'ghost';
+    viewBtn.textContent = 'Ver escena';
+    actions.appendChild(viewBtn);
+
+    const initialBtn = document.createElement('button');
+    initialBtn.type = 'button';
+    initialBtn.dataset.action = 'initial';
+    initialBtn.className = 'ghost';
+    if (state.initialSceneId === scene.id) {
+      initialBtn.classList.add('is-initial');
+      initialBtn.textContent = 'Inicio actual';
+    } else {
+      initialBtn.textContent = 'Marcar inicio';
+    }
+    actions.appendChild(initialBtn);
+
+    details.appendChild(actions);
+    li.appendChild(details);
+    fragment.appendChild(li);
+  });
+
+  scenesListEl.innerHTML = '';
+  scenesListEl.appendChild(fragment);
+}
+
+function renderHotspotList(scene) {
+  hotspotsListEl.innerHTML = '';
+  if (!scene || !scene.hotspots.length) {
+    const empty = document.createElement('li');
+    empty.className = 'scene-empty';
+    empty.textContent = 'No hay hotspots en esta escena todavía.';
+    hotspotsListEl.appendChild(empty);
+    hotspotCountEl.textContent = '0 hotspots';
+    return;
+  }
+
+  hotspotCountEl.textContent = `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'}`;
+
+  const fragment = document.createDocumentFragment();
+  scene.hotspots.forEach((hotspot) => {
+    const item = document.createElement('li');
+    item.className = 'hotspot-item';
+    item.dataset.id = hotspot.id;
+
+    const meta = document.createElement('div');
+    meta.className = 'hotspot-meta';
+    const label = document.createElement('strong');
+    label.textContent = hotspot.label;
+    const targetScene = getSceneById(hotspot.targetSceneId);
+    const hint = document.createElement('span');
+    hint.textContent = targetScene ? `Dirige a: ${targetScene.name}` : 'Sin escena destino';
+    meta.appendChild(label);
+    meta.appendChild(hint);
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'danger';
+    remove.dataset.id = hotspot.id;
+    remove.textContent = 'Eliminar';
+
+    item.appendChild(meta);
+    item.appendChild(remove);
+    fragment.appendChild(item);
+  });
+  hotspotsListEl.appendChild(fragment);
+}
+
+function updateViewerMarkers(scene) {
+  if (!markersPlugin) return;
+  markersPlugin.clearMarkers();
+  (scene.hotspots || []).forEach((hotspot) => {
+    const target = getSceneById(hotspot.targetSceneId);
+    const tooltip = target
+      ? `<strong>${escapeHtml(hotspot.label)}</strong><br/><span>${escapeHtml(target.name)}</span>`
+      : `<strong>${escapeHtml(hotspot.label)}</strong>`;
+    markersPlugin.addMarker({
+      id: hotspot.id,
+      longitude: hotspot.yaw,
+      latitude: hotspot.pitch,
+      html: '<div class="hotspot-pin"></div>',
+      anchor: 'bottom center',
+      tooltip: { content: tooltip },
+      data: { targetSceneId: hotspot.targetSceneId },
+    });
+  });
+}
+
+function escapeHtml(text = '') {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function ensureViewer(scene) {
+  if (viewer) {
+    viewer.setPanorama(scene.url);
+    return;
+  }
+
+  viewer = new PhotoSphereViewer.Viewer({
+    container: document.getElementById('viewer'),
+    panorama: scene.url,
+    navbar: ['zoom', 'move', 'fullscreen'],
+    mousewheelCtrlKey: true,
+    touchmoveTwoFingers: true,
+    backgroundColor: '#050714',
+    plugins: [[PhotoSphereViewer.MarkersPlugin, { markers: [] }]],
+  });
+
+  markersPlugin = viewer.getPlugin(PhotoSphereViewer.MarkersPlugin);
+
+  viewer.addEventListener('panorama-loaded', () => {
+    const current = getCurrentScene();
+    if (current) {
+      viewerTitleEl.textContent = current.name;
+      viewerHintEl.textContent = current.hotspots.length
+        ? `${current.hotspots.length} hotspot${current.hotspots.length === 1 ? '' : 's'} listos`
+        : 'Aún no hay hotspots en esta escena';
+      updateViewerMarkers(current);
+    }
+  });
+
+  viewer.addEventListener('click', (event) => {
+    if (!placingHotspot) return;
+    placingHotspot = false;
+    placingNotice.classList.add('hidden');
+    pendingCoords = {
+      yaw: event.data.longitude,
+      pitch: event.data.latitude,
+    };
+    openHotspotModal();
+  });
+
+  markersPlugin.addEventListener('select-marker', (event) => {
+    const marker = event.marker;
+    if (!marker || !marker.config || !marker.config.data) return;
+    const targetId = marker.config.data.targetSceneId;
+    if (targetId) {
+      activateScene(targetId);
+    }
+  });
+}
+
+function activateScene(sceneId) {
+  const scene = getSceneById(sceneId);
+  if (!scene) return;
+  state.currentSceneId = sceneId;
+  ensureViewer(scene);
+  viewer.setPanorama(scene.url);
+  viewerTitleEl.textContent = scene.name;
+  viewerHintEl.textContent = scene.hotspots.length
+    ? `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'} listos`
+    : 'Aún no hay hotspots en esta escena';
+  renderScenesList();
+  renderHotspotList(scene);
+  hotspotCountEl.textContent = `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'}`;
+}
+
+function resetSceneUpload() {
+  pendingSceneFile = null;
+  sceneNameInput.value = '';
+  sceneModal.classList.add('hidden');
+  confirmSceneModalBtn.disabled = false;
+}
+
+function openSceneModal(file, suggestedName) {
+  pendingSceneFile = file;
+  sceneFileName.textContent = file.name;
+  sceneNameInput.value = suggestedName;
+  sceneModal.classList.remove('hidden');
+  sceneNameInput.focus();
+}
+
+function openHotspotModal() {
+  hotspotModal.classList.remove('hidden');
+  hotspotLabelInput.value = '';
+  hotspotLabelInput.focus();
+  hotspotTargetSelect.innerHTML = '';
+
+  const fragment = document.createDocumentFragment();
+  state.scenes.forEach((scene) => {
+    const option = document.createElement('option');
+    option.value = scene.id;
+    option.textContent = scene.name;
+    if (scene.id === state.currentSceneId) {
+      option.selected = true;
+    }
+    fragment.appendChild(option);
+  });
+  hotspotTargetSelect.appendChild(fragment);
+}
+
+function closeHotspotModal() {
+  hotspotModal.classList.add('hidden');
+  hotspotLabelInput.value = '';
+  hotspotTargetSelect.innerHTML = '';
+  pendingCoords = null;
+}
+
+function startHotspotPlacement() {
+  const current = getCurrentScene();
+  if (!current) {
+    showToast('Primero selecciona una escena', 'error');
+    return;
+  }
+  placingHotspot = true;
+  pendingCoords = null;
+  placingNotice.classList.remove('hidden');
+  showToast('Haz clic en la escena para colocar el hotspot');
+}
+
+async function uploadScene(name) {
+  if (!pendingSceneFile) return;
+  confirmSceneModalBtn.disabled = true;
+  const formData = new FormData();
+  formData.append('scene', pendingSceneFile);
+  formData.append('sceneName', name);
+
+  try {
+    const response = await fetch(`/api/tours/${state.slug}/upload`, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      showToast(error.error || 'No se pudo subir la escena', 'error');
+      resetSceneUpload();
+      return;
+    }
+    const data = await response.json();
+    const newScene = mapScene(data.scene);
+    state.scenes.push(newScene);
+    state.initialSceneId = data.tour.initialSceneId || state.initialSceneId;
+    renderScenesList();
+    if (!state.currentSceneId) {
+      activateScene(newScene.id);
+    }
+    showToast('Escena subida correctamente', 'success');
+  } catch (error) {
+    console.error(error);
+    showToast('Error al subir la escena', 'error');
+  } finally {
+    resetSceneUpload();
+  }
+}
+
+async function saveTour() {
+  if (!state.slug) return;
+  saveTourBtn.disabled = true;
+  const payload = {
+    title: state.title,
+    initialSceneId: state.initialSceneId,
+    scenes: state.scenes.map((scene) => ({
+      id: scene.id,
+      name: scene.name,
+      file: scene.file,
+      hotspots: scene.hotspots.map((spot) => ({
+        id: spot.id,
+        label: spot.label,
+        targetSceneId: spot.targetSceneId,
+        yaw: spot.yaw,
+        pitch: spot.pitch,
+      })),
+    })),
+  };
+
+  try {
+    const response = await fetch(`/api/tours/${state.slug}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      showToast(error.error || 'No se pudo guardar el tour', 'error');
+      return;
+    }
+    const data = await response.json();
+    state.title = data.title;
+    state.initialSceneId = data.initialSceneId;
+    state.scenes = data.scenes.map(mapScene);
+    if (state.currentSceneId) {
+      const refreshed = getSceneById(state.currentSceneId);
+      if (refreshed) {
+        renderHotspotList(refreshed);
+        updateViewerMarkers(refreshed);
+      }
+    }
+    renderScenesList();
+    showToast('Tour guardado', 'success');
+  } catch (error) {
+    console.error(error);
+    showToast('Error de conexión al guardar', 'error');
+  } finally {
+    saveTourBtn.disabled = false;
+  }
+}
+
+createForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const name = tourNameInput.value.trim();
+  const title = tourTitleInput.value.trim();
+  if (!name) {
+    showToast('Escribe un nombre para tu tour', 'error');
+    return;
+  }
+  const payload = { name, title };
+  try {
+    const response = await fetch('/api/tours', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      showToast(data.error || 'No se pudo crear el tour', 'error');
+      return;
+    }
+    state.slug = data.slug;
+    state.title = data.title;
+    state.initialSceneId = data.initialSceneId;
+    state.scenes = (data.scenes || []).map(mapScene);
+    createPanel.classList.add('hidden');
+    workspace.classList.remove('hidden');
+    tourFolderInfo.textContent = `Carpeta actual: /${state.slug}`;
+    tourPublicLink.href = `/${state.slug}`;
+    tourPublicLink.textContent = `${normalizeOrigin()}/${state.slug}`;
+    tourPublicLink.classList.remove('hidden');
+    renderScenesList();
+    if (state.initialSceneId) {
+      activateScene(state.initialSceneId);
+    }
+    showToast('Tour listo para editar', 'success');
+  } catch (error) {
+    console.error(error);
+    showToast('No se pudo conectar con el servidor', 'error');
+  }
+});
+
+sceneUploadInput.addEventListener('change', (event) => {
+  if (!state.slug) {
+    showToast('Crea un tour antes de subir escenas', 'error');
+    sceneUploadInput.value = '';
+    return;
+  }
+  const file = event.target.files && event.target.files[0];
+  if (!file) return;
+  const suggested = file.name.replace(/\.[^.]+$/, '').replace(/[_-]+/g, ' ');
+  openSceneModal(file, suggested);
+  sceneUploadInput.value = '';
+});
+
+confirmSceneModalBtn.addEventListener('click', () => {
+  if (!pendingSceneFile) return;
+  const sceneName = sceneNameInput.value.trim() || pendingSceneFile.name.replace(/\.[^.]+$/, '');
+  uploadScene(sceneName);
+});
+
+cancelSceneModalBtn.addEventListener('click', resetSceneUpload);
+
+sceneModal.addEventListener('click', (event) => {
+  if (event.target === sceneModal) {
+    resetSceneUpload();
+  }
+});
+
+confirmHotspotBtn.addEventListener('click', () => {
+  const scene = getCurrentScene();
+  if (!scene || !pendingCoords) {
+    closeHotspotModal();
+    return;
+  }
+  const label = hotspotLabelInput.value.trim();
+  const targetSceneId = hotspotTargetSelect.value;
+  if (!label) {
+    showToast('Escribe una etiqueta para el hotspot', 'error');
+    return;
+  }
+  if (!targetSceneId) {
+    showToast('Elige una escena destino', 'error');
+    return;
+  }
+  const hotspot = {
+    id: `hotspot-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`,
+    label,
+    targetSceneId,
+    yaw: pendingCoords.yaw,
+    pitch: pendingCoords.pitch,
+  };
+  scene.hotspots.push(hotspot);
+  closeHotspotModal();
+  renderHotspotList(scene);
+  updateViewerMarkers(scene);
+  showToast('Hotspot agregado', 'success');
+});
+
+cancelHotspotBtn.addEventListener('click', () => {
+  closeHotspotModal();
+});
+
+hotspotModal.addEventListener('click', (event) => {
+  if (event.target === hotspotModal) {
+    closeHotspotModal();
+  }
+});
+
+hotspotsListEl.addEventListener('click', (event) => {
+  const button = event.target.closest('button[data-id]');
+  if (!button) return;
+  const scene = getCurrentScene();
+  if (!scene) return;
+  const hotspotId = button.dataset.id;
+  scene.hotspots = scene.hotspots.filter((spot) => spot.id !== hotspotId);
+  renderHotspotList(scene);
+  updateViewerMarkers(scene);
+  showToast('Hotspot eliminado', 'success');
+});
+
+scenesListEl.addEventListener('click', (event) => {
+  const actionButton = event.target.closest('button[data-action]');
+  if (!actionButton) return;
+  const item = actionButton.closest('li[data-id]');
+  if (!item) return;
+  const sceneId = item.dataset.id;
+
+  if (actionButton.dataset.action === 'view') {
+    activateScene(sceneId);
+  } else if (actionButton.dataset.action === 'initial') {
+    state.initialSceneId = sceneId;
+    renderScenesList();
+    showToast('Escena marcada como inicio', 'success');
+  }
+});
+
+addHotspotBtn.addEventListener('click', () => {
+  startHotspotPlacement();
+});
+
+saveTourBtn.addEventListener('click', () => {
+  saveTour();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    if (!sceneModal.classList.contains('hidden')) {
+      resetSceneUpload();
+    }
+    if (!hotspotModal.classList.contains('hidden')) {
+      closeHotspotModal();
+    }
+    if (placingHotspot) {
+      placingHotspot = false;
+      placingNotice.classList.add('hidden');
+      pendingCoords = null;
+    }
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  hideToast();
+});
+
+updateSlugPreview();

--- a/public/js/viewer.js
+++ b/public/js/viewer.js
@@ -1,0 +1,179 @@
+const viewerContainer = document.getElementById('viewer');
+const tourTitleEl = document.getElementById('tourTitle');
+const tourSubtitleEl = document.getElementById('tourSubtitle');
+const tourPathEl = document.getElementById('tourPath');
+const sceneSelect = document.getElementById('sceneSelect');
+const messageEl = document.getElementById('viewerMessage');
+
+let viewer = null;
+let markersPlugin = null;
+let scenes = [];
+let currentSceneId = null;
+
+function normalizeOrigin() {
+  return window.location.origin && window.location.origin !== 'null'
+    ? window.location.origin
+    : 'tu-dominio';
+}
+
+function escapeHtml(text = '') {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function mapScene(slug, scene) {
+  return {
+    id: scene.id,
+    name: scene.name,
+    file: scene.file,
+    hotspots: (scene.hotspots || []).map((spot) => ({
+      id: spot.id,
+      label: spot.label,
+      targetSceneId: spot.targetSceneId,
+      yaw: Number(spot.yaw),
+      pitch: Number(spot.pitch),
+    })),
+    url: scene.url || `/tours/${slug}/${scene.file}`,
+  };
+}
+
+function showMessage(text) {
+  messageEl.textContent = text;
+  messageEl.classList.remove('hidden');
+}
+
+function hideMessage() {
+  messageEl.classList.add('hidden');
+}
+
+function updateSceneOptions() {
+  sceneSelect.innerHTML = '';
+  if (!scenes.length) {
+    sceneSelect.disabled = true;
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  scenes.forEach((scene) => {
+    const option = document.createElement('option');
+    option.value = scene.id;
+    option.textContent = scene.name;
+    if (scene.id === currentSceneId) {
+      option.selected = true;
+    }
+    fragment.appendChild(option);
+  });
+  sceneSelect.appendChild(fragment);
+  sceneSelect.disabled = scenes.length <= 1;
+}
+
+function renderMarkers(scene) {
+  if (!markersPlugin) return;
+  markersPlugin.clearMarkers();
+  scene.hotspots.forEach((hotspot) => {
+    const target = scenes.find((item) => item.id === hotspot.targetSceneId);
+    const tooltip = target
+      ? `<strong>${escapeHtml(hotspot.label)}</strong><br/><span>${escapeHtml(target.name)}</span>`
+      : `<strong>${escapeHtml(hotspot.label)}</strong>`;
+    markersPlugin.addMarker({
+      id: hotspot.id,
+      longitude: Number(hotspot.yaw),
+      latitude: Number(hotspot.pitch),
+      html: '<div class="hotspot-pin"></div>',
+      anchor: 'bottom center',
+      tooltip: { content: tooltip },
+      data: { targetSceneId: hotspot.targetSceneId },
+    });
+  });
+}
+
+function updateSceneInfo(scene) {
+  tourSubtitleEl.textContent = scene.hotspots.length
+    ? `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'} interactivo${scene.hotspots.length === 1 ? '' : 's'}`
+    : 'Esta escena aún no tiene hotspots.';
+}
+
+function setScene(sceneId) {
+  if (!viewer) return;
+  if (sceneId === currentSceneId) {
+    return;
+  }
+  const scene = scenes.find((item) => item.id === sceneId);
+  if (!scene) return;
+  currentSceneId = sceneId;
+  viewer.setPanorama(scene.url);
+  updateSceneOptions();
+  updateSceneInfo(scene);
+}
+
+function initializeViewer(initialScene) {
+  viewer = new PhotoSphereViewer.Viewer({
+    container: viewerContainer,
+    panorama: initialScene.url,
+    navbar: ['zoom', 'move', 'fullscreen'],
+    mousewheelCtrlKey: true,
+    touchmoveTwoFingers: true,
+    backgroundColor: '#050714',
+    plugins: [[PhotoSphereViewer.MarkersPlugin, { markers: [] }]],
+  });
+  markersPlugin = viewer.getPlugin(PhotoSphereViewer.MarkersPlugin);
+
+  viewer.addEventListener('panorama-loaded', () => {
+    const scene = scenes.find((item) => item.id === currentSceneId);
+    if (scene) {
+      renderMarkers(scene);
+      updateSceneInfo(scene);
+    }
+  });
+
+  markersPlugin.addEventListener('select-marker', (event) => {
+    const marker = event.marker;
+    if (!marker || !marker.config || !marker.config.data) return;
+    const targetId = marker.config.data.targetSceneId;
+    if (targetId) {
+      setScene(targetId);
+      sceneSelect.value = targetId;
+    }
+  });
+}
+
+async function loadTour(slug) {
+  tourPathEl.textContent = `${normalizeOrigin()}/${slug}`;
+  try {
+    const response = await fetch(`/api/tours/${slug}`);
+    if (!response.ok) {
+      showMessage('No pudimos encontrar este tour.');
+      return;
+    }
+    const data = await response.json();
+    scenes = (data.scenes || []).map((scene) => mapScene(slug, scene));
+    tourTitleEl.textContent = data.title || slug;
+    if (!scenes.length) {
+      showMessage('Este tour aún no tiene escenas publicadas.');
+      return;
+    }
+    hideMessage();
+    const initialScene = scenes.find((scene) => scene.id === data.initialSceneId) || scenes[0];
+    currentSceneId = initialScene.id;
+    updateSceneOptions();
+    initializeViewer(initialScene);
+    updateSceneInfo(initialScene);
+    sceneSelect.value = currentSceneId;
+  } catch (error) {
+    console.error(error);
+    showMessage('Ha ocurrido un error al cargar el tour.');
+  }
+}
+
+sceneSelect.addEventListener('change', (event) => {
+  setScene(event.target.value);
+});
+
+const segments = window.location.pathname.split('/').filter(Boolean);
+const slug = decodeURIComponent(segments[0] || '');
+
+if (!slug) {
+  showMessage('Para ver un tour ingresa con la ruta /tu-carpeta.');
+} else {
+  loadTour(slug);
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,566 @@
+:root {
+  --bg: #050714;
+  --bg-alt: #090c1f;
+  --panel: #11162c;
+  --panel-alt: rgba(40, 58, 112, 0.35);
+  --text: #f6f7ff;
+  --muted: #8da2d6;
+  --accent: #4f9cff;
+  --accent-secondary: #9b5cff;
+  --danger: #ff5f7d;
+  --success: #4cd2b1;
+  --border: rgba(118, 144, 212, 0.25);
+  --shadow: 0 24px 48px rgba(10, 14, 35, 0.55);
+  font-family: "Outfit", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(79, 156, 255, 0.15), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(155, 92, 255, 0.12), transparent 40%),
+    var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  display: flex;
+  justify-content: center;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  width: min(1200px, 96vw);
+  padding: 3.5rem 0 4rem;
+}
+
+.hero {
+  margin-bottom: 2rem;
+  background: linear-gradient(135deg, rgba(79, 156, 255, 0.2), rgba(155, 92, 255, 0.08));
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2.5rem 3rem;
+  box-shadow: var(--shadow);
+}
+
+.hero-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.76rem;
+  color: var(--muted);
+  margin: 0 0 0.75rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  font-weight: 600;
+}
+
+.hero-subtitle {
+  margin: 1rem 0 0;
+  color: var(--muted);
+  max-width: 48rem;
+  line-height: 1.6;
+}
+
+.creation-panel {
+  margin-bottom: 2.5rem;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2rem 2.5rem;
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.card h2 {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.6rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.field label,
+.field span {
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+input,
+select {
+  background: rgba(12, 17, 36, 0.85);
+  border: 1px solid rgba(118, 144, 212, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  color: var(--text);
+  font: inherit;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(79, 156, 255, 0.22);
+}
+
+small {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 1.3rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+  color: var(--text);
+  box-shadow: 0 12px 24px rgba(79, 156, 255, 0.35);
+}
+
+button.primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+button.ghost {
+  background: rgba(79, 156, 255, 0.08);
+  color: var(--text);
+  border: 1px solid rgba(79, 156, 255, 0.3);
+}
+
+button.ghost:hover:not(:disabled) {
+  background: rgba(79, 156, 255, 0.18);
+}
+
+button.danger {
+  background: rgba(255, 95, 125, 0.18);
+  border: 1px solid rgba(255, 95, 125, 0.45);
+  color: var(--text);
+}
+
+button.danger:hover:not(:disabled) {
+  background: rgba(255, 95, 125, 0.28);
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--muted);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 2rem;
+}
+
+.sidebar {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.75rem 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  height: fit-content;
+}
+
+.sidebar-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.sidebar-info {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.upload-label {
+  display: grid;
+  place-items: center;
+  padding: 1.2rem;
+  border-radius: 16px;
+  background: rgba(79, 156, 255, 0.08);
+  border: 1px dashed rgba(79, 156, 255, 0.35);
+  color: var(--accent);
+  font-weight: 500;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.upload-label:hover {
+  background: rgba(79, 156, 255, 0.15);
+}
+
+.upload-label input {
+  display: none;
+}
+
+.tour-link {
+  font-size: 0.85rem;
+  color: var(--accent);
+  word-break: break-all;
+}
+
+.scene-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.scene-item {
+  background: rgba(17, 25, 46, 0.85);
+  border: 1px solid rgba(79, 156, 255, 0.18);
+  border-radius: 16px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 1rem;
+  padding: 0.75rem;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.scene-item.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(79, 156, 255, 0.35);
+}
+
+.scene-thumb {
+  width: 96px;
+  height: 96px;
+  border-radius: 12px;
+  object-fit: cover;
+  background: rgba(15, 20, 35, 0.75);
+}
+
+.scene-details {
+  display: grid;
+  gap: 0.55rem;
+  align-content: center;
+}
+
+.scene-name {
+  font-weight: 500;
+}
+
+.scene-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.scene-actions button {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+}
+
+.scene-actions .is-initial {
+  background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+  border: none;
+  box-shadow: 0 8px 16px rgba(79, 156, 255, 0.3);
+}
+
+.scene-empty {
+  padding: 1.5rem;
+  text-align: center;
+  border-radius: 16px;
+  border: 1px dashed rgba(79, 156, 255, 0.2);
+  color: var(--muted);
+}
+
+.viewer-area {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.viewer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.viewer-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.viewer-shell {
+  position: relative;
+  border-radius: 22px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--panel-alt);
+  box-shadow: var(--shadow);
+}
+
+.viewer {
+  width: 100%;
+  height: clamp(320px, 55vh, 520px);
+  background: radial-gradient(circle, rgba(79, 156, 255, 0.08), transparent 70%);
+}
+
+.placing {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(9, 12, 31, 0.78);
+}
+
+.hotspots-panel {
+  background: rgba(17, 23, 43, 0.78);
+  border-radius: 20px;
+  border: 1px solid rgba(79, 156, 255, 0.15);
+  padding: 1.3rem 1.5rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.hotspots-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.hotspot-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hotspot-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(19, 27, 48, 0.85);
+  border: 1px solid rgba(79, 156, 255, 0.18);
+}
+
+.hotspot-meta {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hotspot-meta span {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.hotspot-item button {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 6, 18, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.modal-content {
+  background: linear-gradient(145deg, rgba(17, 23, 42, 0.95), rgba(9, 13, 28, 0.95));
+  border: 1px solid rgba(79, 156, 255, 0.25);
+  border-radius: 20px;
+  padding: 2rem 2.2rem;
+  width: min(420px, 90vw);
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(17, 23, 42, 0.95);
+  padding: 1rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 156, 255, 0.35);
+  min-width: 240px;
+  text-align: center;
+  box-shadow: var(--shadow);
+  z-index: 30;
+}
+
+.toast.success {
+  border-color: rgba(76, 210, 177, 0.5);
+  color: var(--success);
+}
+
+.toast.error {
+  border-color: rgba(255, 95, 125, 0.55);
+  color: var(--danger);
+}
+
+.viewer-body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% -10%, rgba(155, 92, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 90% 10%, rgba(79, 156, 255, 0.15), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+}
+
+.viewer-app {
+  width: min(1200px, 96vw);
+  padding: 2.5rem 0 3rem;
+  display: grid;
+  gap: 1.8rem;
+}
+
+.viewer-bar {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem 2.5rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-end;
+}
+
+.viewer-controls {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.viewer-controls select {
+  min-width: 200px;
+}
+
+.viewer-stage {
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  background: var(--panel-alt);
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.viewer-message {
+  margin-top: 1rem;
+  background: rgba(19, 27, 48, 0.9);
+  border: 1px solid rgba(79, 156, 255, 0.25);
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.psv-marker svg,
+.psv-marker .hotspot-pin {
+  width: 22px;
+  height: 22px;
+}
+
+.psv-marker .hotspot-pin {
+  background: radial-gradient(circle, var(--accent) 0%, rgba(79, 156, 255, 0.4) 70%, transparent 100%);
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 18px rgba(79, 156, 255, 0.65);
+}
+
+@media (max-width: 1024px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .viewer-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .viewer-controls {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  main,
+  .viewer-app {
+    width: 92vw;
+  }
+
+  .hero,
+  .viewer-bar,
+  .viewer-stage,
+  .card,
+  .sidebar,
+  .hotspots-panel {
+    padding: 1.4rem 1.5rem;
+  }
+
+  .scene-item {
+    grid-template-columns: 72px 1fr;
+  }
+
+  .scene-thumb {
+    width: 72px;
+    height: 72px;
+  }
+}

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Explorar tour 360</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.css"
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="viewer-body">
+    <main class="viewer-app">
+      <header class="viewer-bar">
+        <div class="viewer-texts">
+          <p class="hero-kicker" id="tourPath"></p>
+          <h1 id="tourTitle">Cargando tour...</h1>
+          <p class="hero-subtitle" id="tourSubtitle">
+            Recorre el espacio con los hotspots interactivos.
+          </p>
+        </div>
+        <div class="viewer-controls">
+          <label for="sceneSelect">Escena</label>
+          <select id="sceneSelect" disabled></select>
+        </div>
+      </header>
+      <section class="viewer-stage">
+        <div id="viewer" class="viewer"></div>
+        <div id="viewerMessage" class="viewer-message hidden"></div>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/uevent@2.0.0/browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.js"></script>
+    <script type="module" src="/js/viewer.js"></script>
+  </body>
+</html>

--- a/server.py
+++ b/server.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Minimal backend to manage 360° tour creation and hosting."""
+from __future__ import annotations
+
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="cgi")
+warnings.filterwarnings("ignore", category=DeprecationWarning, message=r".*'cgi' is deprecated.*")
+
+import cgi
+import json
+import os
+import re
+import shutil
+import uuid
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+PUBLIC_DIR = os.path.join(BASE_DIR, "public")
+TOURS_DIR = os.path.join(PUBLIC_DIR, "tours")
+
+
+def ensure_directories() -> None:
+    os.makedirs(TOURS_DIR, exist_ok=True)
+
+
+def slugify(value: str) -> str:
+    """Create a filesystem safe slug from the provided name."""
+    value = (value or "").strip()
+    if not value:
+        return ""
+    normalized = (
+        value.lower()
+        .strip()
+        .replace("_", "-")
+    )
+    normalized = (
+        normalized
+        .encode("ascii", "ignore")
+        .decode("ascii")
+    )
+    normalized = re.sub(r"[^a-z0-9-\s]", "", normalized)
+    normalized = re.sub(r"\s+", "-", normalized)
+    normalized = re.sub(r"-+", "-", normalized)
+    return normalized.strip("-")
+
+
+def is_valid_slug(slug: str) -> bool:
+    return bool(re.match(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$", slug))
+
+
+class TourRequestHandler(SimpleHTTPRequestHandler):
+    """Request handler serving API endpoints and static files."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, directory=PUBLIC_DIR, **kwargs)
+
+    # ------------------------------- helpers ------------------------------- #
+    def _send_json(self, payload: Dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self) -> Dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0:
+            return {}
+        raw = self.rfile.read(length)
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            self._send_json({"error": "JSON inválido"}, HTTPStatus.BAD_REQUEST)
+            raise
+
+    def _tour_dir(self, slug: str) -> str:
+        return os.path.join(TOURS_DIR, slug)
+
+    def _tour_file(self, slug: str) -> str:
+        return os.path.join(self._tour_dir(slug), "tour.json")
+
+    def _tour_exists(self, slug: str) -> bool:
+        return os.path.exists(self._tour_file(slug))
+
+    def _load_tour(self, slug: str) -> Dict[str, Any] | None:
+        try:
+            with open(self._tour_file(slug), "r", encoding="utf-8") as handler:
+                return json.load(handler)
+        except FileNotFoundError:
+            return None
+
+    def _save_tour(self, slug: str, data: Dict[str, Any]) -> None:
+        os.makedirs(self._tour_dir(slug), exist_ok=True)
+        with open(self._tour_file(slug), "w", encoding="utf-8") as handler:
+            json.dump(data, handler, ensure_ascii=False, indent=2)
+
+    def _format_tour_response(self, slug: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        scenes = []
+        for scene in data.get("scenes", []):
+            scene_copy = {
+                "id": scene.get("id"),
+                "name": scene.get("name"),
+                "file": scene.get("file"),
+                "hotspots": scene.get("hotspots", []),
+                "url": f"/tours/{slug}/{scene.get('file')}"
+            }
+            scenes.append(scene_copy)
+        return {
+            "slug": slug,
+            "title": data.get("title", slug),
+            "initialSceneId": data.get("initialSceneId"),
+            "scenes": scenes,
+        }
+
+    def _clean_scene(self, scene: Dict[str, Any]) -> Dict[str, Any]:
+        clean_hotspots = []
+        for hotspot in scene.get("hotspots", []):
+            try:
+                yaw = float(hotspot["yaw"])
+                pitch = float(hotspot["pitch"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            clean_hotspots.append(
+                {
+                    "id": hotspot.get("id") or f"hotspot-{uuid.uuid4().hex}",
+                    "label": hotspot.get("label", "Hotspot"),
+                    "targetSceneId": hotspot.get("targetSceneId"),
+                    "yaw": yaw,
+                    "pitch": pitch,
+                }
+            )
+        return {
+            "id": scene.get("id"),
+            "name": scene.get("name", "Escena"),
+            "file": scene.get("file"),
+            "hotspots": clean_hotspots,
+        }
+
+    def _json_error(self, message: str, status: HTTPStatus) -> None:
+        self._send_json({"error": message}, status)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003 - overrides parent
+        # Quieter logs for a cleaner console.
+        return
+
+    # --------------------------------- GET --------------------------------- #
+    def do_GET(self) -> None:  # noqa: N802 - API from base class
+        parsed = urlparse(self.path)
+        parts = parsed.path.strip("/").split("/") if parsed.path else []
+
+        if parts[:2] == ["api", "tours"]:
+            if len(parts) == 3 and parts[2]:
+                slug = parts[2].lower()
+                if not is_valid_slug(slug):
+                    self._json_error("Carpeta del tour inválida", HTTPStatus.BAD_REQUEST)
+                    return
+                tour_data = self._load_tour(slug)
+                if not tour_data:
+                    self._json_error("Tour no encontrado", HTTPStatus.NOT_FOUND)
+                    return
+                response = self._format_tour_response(slug, tour_data)
+                response["folderPath"] = f"/{slug}"
+                self._send_json(response)
+                return
+            self._json_error("Endpoint no encontrado", HTTPStatus.NOT_FOUND)
+            return
+
+        # Serve viewer when accessing /<slug> without extension
+        if parsed.path not in ("", "/"):
+            slug_candidate = parsed.path.strip("/")
+            if slug_candidate and "." not in os.path.basename(slug_candidate):
+                slug = slug_candidate.lower()
+                if is_valid_slug(slug) and self._tour_exists(slug):
+                    self.path = "/viewer.html"
+        return super().do_GET()
+
+    # --------------------------------- POST -------------------------------- #
+    def do_POST(self) -> None:  # noqa: N802 - API from base class
+        parsed = urlparse(self.path)
+        parts = parsed.path.strip("/").split("/") if parsed.path else []
+
+        if parts[:2] != ["api", "tours"]:
+            self._json_error("Endpoint no encontrado", HTTPStatus.NOT_FOUND)
+            return
+
+        if len(parts) == 2:
+            self._handle_create_tour()
+            return
+
+        if len(parts) >= 3:
+            slug = parts[2].lower()
+            if not is_valid_slug(slug):
+                self._json_error("Carpeta del tour inválida", HTTPStatus.BAD_REQUEST)
+                return
+
+            if len(parts) == 4 and parts[3] == "upload":
+                self._handle_scene_upload(slug)
+                return
+            if len(parts) == 4 and parts[3] == "save":
+                self._handle_save_tour(slug)
+                return
+
+        self._json_error("Endpoint no encontrado", HTTPStatus.NOT_FOUND)
+
+    # ------------------------------- handlers ------------------------------ #
+    def _handle_create_tour(self) -> None:
+        try:
+            payload = self._read_json()
+        except json.JSONDecodeError:
+            return
+
+        name = (payload.get("name") or "").strip()
+        title = (payload.get("title") or "").strip()
+
+        if not name:
+            self._json_error("Debes indicar un nombre para la carpeta", HTTPStatus.BAD_REQUEST)
+            return
+
+        slug = slugify(name)
+        if not slug or not is_valid_slug(slug):
+            self._json_error(
+                "El nombre solo puede contener letras, números y guiones",
+                HTTPStatus.BAD_REQUEST,
+            )
+            return
+
+        tour_dir = self._tour_dir(slug)
+        os.makedirs(tour_dir, exist_ok=True)
+        tour_data = self._load_tour(slug)
+        if not tour_data:
+            tour_data = {
+                "slug": slug,
+                "title": title or name,
+                "initialSceneId": None,
+                "scenes": [],
+            }
+        else:
+            if title:
+                tour_data["title"] = title
+
+        self._save_tour(slug, tour_data)
+        response = self._format_tour_response(slug, tour_data)
+        response["folderPath"] = f"/{slug}"
+        self._send_json(response, HTTPStatus.CREATED)
+
+    def _handle_scene_upload(self, slug: str) -> None:
+        tour_data = self._load_tour(slug)
+        if not tour_data:
+            self._json_error("Primero debes crear el tour", HTTPStatus.NOT_FOUND)
+            return
+
+        content_type = self.headers.get("Content-Type")
+        if not content_type or not content_type.startswith("multipart/form-data"):
+            self._json_error("Se esperaba un formulario de tipo multipart", HTTPStatus.BAD_REQUEST)
+            return
+
+        form = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": content_type,
+            },
+        )
+
+        if "scene" not in form:
+            self._json_error("Debes adjuntar una fotografía 360", HTTPStatus.BAD_REQUEST)
+            return
+
+        file_item = form["scene"]
+        if not getattr(file_item, "filename", ""):
+            self._json_error("Archivo de escena inválido", HTTPStatus.BAD_REQUEST)
+            return
+
+        raw_filename = os.path.basename(file_item.filename)
+        _, ext = os.path.splitext(raw_filename)
+        ext = ext.lower() or ".jpg"
+        if ext not in {".jpg", ".jpeg", ".png", ".webp"}:
+            self._json_error("Formato no soportado. Usa JPG, PNG o WEBP", HTTPStatus.BAD_REQUEST)
+            return
+
+        scene_name = (form.getfirst("sceneName") or os.path.splitext(raw_filename)[0] or "Escena").strip()
+        if not scene_name:
+            scene_name = "Escena"
+
+        scene_id = f"scene-{uuid.uuid4().hex}"
+        filename = f"{scene_id}{ext}"
+        tour_dir = self._tour_dir(slug)
+        os.makedirs(tour_dir, exist_ok=True)
+        file_path = os.path.join(tour_dir, filename)
+
+        with open(file_path, "wb") as output:
+            shutil.copyfileobj(file_item.file, output)
+
+        new_scene = {
+            "id": scene_id,
+            "name": scene_name,
+            "file": filename,
+            "hotspots": [],
+        }
+        tour_data.setdefault("scenes", []).append(new_scene)
+        if not tour_data.get("initialSceneId"):
+            tour_data["initialSceneId"] = scene_id
+
+        self._save_tour(slug, tour_data)
+
+        response_scene = dict(new_scene)
+        response_scene["url"] = f"/tours/{slug}/{filename}"
+        response = {
+            "scene": response_scene,
+            "tour": {
+                "initialSceneId": tour_data.get("initialSceneId"),
+            },
+        }
+        self._send_json(response, HTTPStatus.CREATED)
+
+    def _handle_save_tour(self, slug: str) -> None:
+        tour_data = self._load_tour(slug)
+        if not tour_data:
+            self._json_error("Tour no encontrado", HTTPStatus.NOT_FOUND)
+            return
+
+        try:
+            payload = self._read_json()
+        except json.JSONDecodeError:
+            return
+
+        scenes_payload = payload.get("scenes", [])
+        cleaned_scenes = []
+        for scene in scenes_payload:
+            cleaned = self._clean_scene(scene)
+            if not cleaned.get("id") or not cleaned.get("file"):
+                continue
+            if not cleaned.get("name"):
+                cleaned["name"] = "Escena"
+            cleaned_scenes.append(cleaned)
+
+        tour_data["scenes"] = cleaned_scenes
+
+        title = (payload.get("title") or "").strip()
+        if title:
+            tour_data["title"] = title
+
+        initial_scene = payload.get("initialSceneId")
+        if initial_scene and any(scene["id"] == initial_scene for scene in cleaned_scenes):
+            tour_data["initialSceneId"] = initial_scene
+        elif cleaned_scenes:
+            tour_data["initialSceneId"] = cleaned_scenes[0]["id"]
+        else:
+            tour_data["initialSceneId"] = None
+
+        self._save_tour(slug, tour_data)
+        response = self._format_tour_response(slug, tour_data)
+        response["folderPath"] = f"/{slug}"
+        self._send_json(response)
+
+
+def run() -> None:
+    ensure_directories()
+    port = int(os.environ.get("PORT", "8000"))
+    server = ThreadingHTTPServer(("0.0.0.0", port), TourRequestHandler)
+    print(f"\nTour 360 server disponible en http://localhost:{port}\n")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nServidor detenido")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add a Python HTTP server that persists tours, handles uploads and serves static assets
- build a dark futuristic single-page builder UI to upload 360 scenes and manage hotspots
- create a public tour viewer plus styling and documentation for running the experience

## Testing
- python3 -m py_compile server.py
- python3 server.py

------
https://chatgpt.com/codex/tasks/task_e_68c939ee7e388330b1d171cc5dede0ef