### PR TITLE
Replace Python backend with PHP API for Plesk hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+public/tours/*
+!public/tours/.gitignore
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# tour360
+# Tour360 Studio
+
+Plataforma minimalista en tonos oscuros que permite crear y compartir tours 360°. Los usuarios pueden subir panorámicas, previsualizarlas, generar hotspots interactivos y guardar el resultado dentro de una carpeta accesible desde `dominio/carpeta`.
+
+## Características
+
+- **Creación de proyectos** con un nombre de carpeta que define la URL pública.
+- **Carga de fotografías 360°** (JPG, PNG o WEBP) con administración de escenas.
+- **Visualizador interactivo** basado en Photo Sphere Viewer.
+- **Hotspots enlazados** entre escenas para recorrer el espacio.
+- **Publicación automática** del tour en `/<carpeta>` para visitantes.
+
+## Requisitos
+
+- PHP 8.1 o superior con extensiones estándar habilitadas (funciona en la mayoría de los hostings Plesk).
+- Permisos de escritura sobre la carpeta donde se desplegará el proyecto (para crear directorios de tours y guardar imágenes).
+- Acceso a Internet para cargar los assets CDN (Photo Sphere Viewer y fuentes).
+
+## Ejecutar en local (opcional)
+
+Puedes usar el servidor embebido de PHP para previsualizar la herramienta:
+
+```bash
+php -S 0.0.0.0:8000 -t public
+```
+
+Visita `http://localhost:8000` para abrir el constructor de tours.
+
+## Despliegue en Plesk
+
+1. Copia el contenido de la carpeta `public/` dentro del directorio `httpdocs` (o la raíz del dominio) mediante FTP o el gestor de archivos de Plesk.
+2. Asegúrate de subir también el archivo oculto `.htaccess`; es el encargado de redirigir las rutas `/<carpeta>` hacia el visor PHP.
+3. Comprueba que PHP está habilitado para el dominio y que `upload_max_filesize` / `post_max_size` soportan el tamaño de tus panorámicas.
+4. Verifica que el usuario del hosting tenga permisos de escritura sobre `httpdocs/tours`, ya que ahí se guardarán las imágenes y el `tour.json` de cada proyecto.
+
+Una vez desplegado, accede al dominio y crea un tour: cada carpeta quedará publicada automáticamente en `https://tudominio.com/<carpeta>`.
+
+## Flujo de trabajo
+
+1. En la página principal introduce el nombre de la carpeta (solo letras, números y guiones) y un título opcional.
+2. Sube tus panorámicas 360°; cada escena se puede abrir y visualizar inmediatamente.
+3. Selecciona una escena, pulsa **Añadir hotspot** y haz clic sobre la vista para ubicarlo. Define la etiqueta y la escena destino.
+4. Marca la escena inicial del tour y guarda los cambios.
+5. Comparte el enlace generado (`http://localhost:8000/tu-carpeta`) para que otros recorran el tour.
+
+## Estructura
+
+- `public/api/*.php`: endpoints PHP que gestionan la creación de carpetas, subida de escenas e información del tour.
+- `public/index.html`: interfaz de edición de tours.
+- `public/viewer.php`: visor público para los tours guardados.
+- `public/js`: lógica de la app (constructor y visor).
+- `public/styles.css`: estilos oscuros de inspiración futurista.
+
+Los tours se almacenan en `public/tours/<carpeta>` junto con un archivo `tour.json` que describe escenas y hotspots.
+
+## Notas
+
+- Las imágenes 360° deben estar en formato equirectangular para una visualización correcta.
+- Los hotspots pueden apuntar a cualquier escena existente, incluida la actual.
+- El backend está construido en PHP puro, por lo que no requiere frameworks adicionales ni gestor de paquetes.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "tour360-studio",
+  "version": "1.0.0",
+  "description": "Constructor minimalista de tours 360° con hotspots interactivos.",
+  "scripts": {
+    "start": "php -S 0.0.0.0:8000 -t public"
+  },
+  "keywords": ["360", "tour", "viewer", "panorama"],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,7 @@
+RewriteEngine On
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+
+RewriteRule ^([a-z0-9-]+)/?$ viewer.php?slug=$1 [L,QSA]

--- a/public/api/bootstrap.php
+++ b/public/api/bootstrap.php
@@ -1,0 +1,217 @@
+<?php
+declare(strict_types=1);
+
+const TOUR_STORAGE = __DIR__ . '/../tours';
+
+$RESERVED_SLUGS = [
+    'api',
+    'css',
+    'img',
+    'images',
+    'js',
+    'vendor',
+    'assets',
+    'tours',
+    'viewer',
+    'index',
+    'favicon',
+];
+
+if (!is_dir(TOUR_STORAGE) && !mkdir(TOUR_STORAGE, 0775, true) && !is_dir(TOUR_STORAGE)) {
+    send_json(['error' => 'No se pudo preparar el almacenamiento de tours'], 500);
+}
+
+function send_json(array $payload, int $status = 200): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function read_json_input(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === false || $raw === '') {
+        return [];
+    }
+    $data = json_decode($raw, true);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($data)) {
+        send_json(['error' => 'JSON inválido'], 400);
+    }
+    return $data;
+}
+
+function slugify(string $value): string
+{
+    $value = trim($value);
+    if ($value === '') {
+        return '';
+    }
+    $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT', $value);
+    if ($transliterated === false) {
+        $transliterated = $value;
+    }
+    $transliterated = strtolower($transliterated);
+    $transliterated = preg_replace('/[^a-z0-9\s-]/', '', $transliterated) ?? '';
+    $transliterated = preg_replace('/[\s-]+/', '-', $transliterated) ?? '';
+    return trim($transliterated, '-');
+}
+
+function is_valid_slug(string $slug): bool
+{
+    return (bool) preg_match('/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/', $slug);
+}
+
+function ensure_slug_is_allowed(string $slug): void
+{
+    global $RESERVED_SLUGS;
+    if (in_array($slug, $RESERVED_SLUGS, true)) {
+        send_json(['error' => 'Este nombre está reservado, elige otro'], 400);
+    }
+}
+
+function tours_dir(string $slug = ''): string
+{
+    $base = rtrim(TOUR_STORAGE, DIRECTORY_SEPARATOR);
+    if ($slug === '') {
+        return $base;
+    }
+    return $base . DIRECTORY_SEPARATOR . $slug;
+}
+
+function tour_file(string $slug): string
+{
+    return tours_dir($slug) . DIRECTORY_SEPARATOR . 'tour.json';
+}
+
+function load_tour(string $slug): ?array
+{
+    $path = tour_file($slug);
+    if (!is_file($path)) {
+        return null;
+    }
+    $contents = file_get_contents($path);
+    if ($contents === false) {
+        return null;
+    }
+    $data = json_decode($contents, true);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($data)) {
+        return null;
+    }
+    return $data;
+}
+
+function save_tour(string $slug, array $data): void
+{
+    $dir = tours_dir($slug);
+    if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+        send_json(['error' => 'No se pudo guardar el tour'], 500);
+    }
+    $path = tour_file($slug);
+    $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($json === false || file_put_contents($path, $json) === false) {
+        send_json(['error' => 'No se pudo guardar el tour'], 500);
+    }
+}
+
+function format_scene(string $slug, array $scene): array
+{
+    return [
+        'id' => $scene['id'] ?? null,
+        'name' => $scene['name'] ?? 'Escena',
+        'file' => $scene['file'] ?? null,
+        'hotspots' => $scene['hotspots'] ?? [],
+        'url' => sprintf('/tours/%s/%s', $slug, $scene['file'] ?? ''),
+    ];
+}
+
+function format_tour_response(string $slug, array $data): array
+{
+    $scenes = [];
+    foreach ($data['scenes'] ?? [] as $scene) {
+        if (!isset($scene['file'])) {
+            continue;
+        }
+        $scenes[] = format_scene($slug, $scene);
+    }
+    return [
+        'slug' => $slug,
+        'title' => $data['title'] ?? $slug,
+        'initialSceneId' => $data['initialSceneId'] ?? null,
+        'scenes' => $scenes,
+    ];
+}
+
+function clean_hotspots(array $hotspots): array
+{
+    $clean = [];
+    foreach ($hotspots as $hotspot) {
+        if (!is_array($hotspot)) {
+            continue;
+        }
+        $label = isset($hotspot['label']) ? trim((string) $hotspot['label']) : 'Hotspot';
+        $target = $hotspot['targetSceneId'] ?? null;
+        $id = isset($hotspot['id']) ? preg_replace('/[^a-zA-Z0-9_-]/', '', (string) $hotspot['id']) : null;
+        try {
+            $yaw = isset($hotspot['yaw']) ? (float) $hotspot['yaw'] : null;
+            $pitch = isset($hotspot['pitch']) ? (float) $hotspot['pitch'] : null;
+        } catch (Throwable $th) {
+            $yaw = null;
+            $pitch = null;
+        }
+        if ($yaw === null || $pitch === null) {
+            continue;
+        }
+        if ($id === null || $id === '') {
+            $id = 'hotspot-' . bin2hex(random_bytes(4));
+        }
+        $clean[] = [
+            'id' => $id,
+            'label' => $label === '' ? 'Hotspot' : $label,
+            'targetSceneId' => $target,
+            'yaw' => $yaw,
+            'pitch' => $pitch,
+        ];
+    }
+    return $clean;
+}
+
+function clean_scene(array $scene, string $dir): ?array
+{
+    if (!isset($scene['id'], $scene['file'])) {
+        return null;
+    }
+    $id = preg_replace('/[^a-zA-Z0-9_-]/', '', (string) $scene['id']);
+    $file = basename((string) $scene['file']);
+    if ($id === '' || $file === '') {
+        return null;
+    }
+    $path = $dir . DIRECTORY_SEPARATOR . $file;
+    if (!is_file($path)) {
+        return null;
+    }
+    $name = isset($scene['name']) ? trim((string) $scene['name']) : 'Escena';
+    $hotspots = clean_hotspots(is_array($scene['hotspots'] ?? null) ? $scene['hotspots'] : []);
+    return [
+        'id' => $id,
+        'name' => $name === '' ? 'Escena' : $name,
+        'file' => $file,
+        'hotspots' => $hotspots,
+    ];
+}
+
+function generate_scene_filename(string $extension): string
+{
+    return sprintf('scene-%s.%s', bin2hex(random_bytes(6)), $extension);
+}
+
+function generate_scene_id(): string
+{
+    return 'scene-' . bin2hex(random_bytes(6));
+}
+
+function allowed_extension(string $extension): bool
+{
+    return in_array(strtolower($extension), ['jpg', 'jpeg', 'png', 'webp'], true);
+}

--- a/public/api/create-tour.php
+++ b/public/api/create-tour.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    send_json(['error' => 'Método no permitido'], 405);
+}
+
+$data = read_json_input();
+$name = isset($data['name']) ? (string) $data['name'] : '';
+$title = isset($data['title']) ? (string) $data['title'] : '';
+
+$slug = slugify($name);
+if ($slug === '') {
+    send_json(['error' => 'Elige un nombre válido para tu tour'], 400);
+}
+if (!is_valid_slug($slug)) {
+    send_json(['error' => 'La carpeta del tour no es válida'], 400);
+}
+ensure_slug_is_allowed($slug);
+
+$dir = tours_dir($slug);
+if (is_dir($dir) || is_file($dir)) {
+    send_json(['error' => 'Ya existe un tour con este nombre'], 409);
+}
+
+if (!mkdir($dir, 0775, true) && !is_dir($dir)) {
+    send_json(['error' => 'No se pudo crear la carpeta del tour'], 500);
+}
+
+$tourData = [
+    'title' => trim($title) === '' ? $name : trim($title),
+    'initialSceneId' => null,
+    'scenes' => [],
+];
+
+save_tour($slug, $tourData);
+
+send_json(format_tour_response($slug, $tourData));

--- a/public/api/get-tour.php
+++ b/public/api/get-tour.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    send_json(['error' => 'Método no permitido'], 405);
+}
+
+$slug = isset($_GET['slug']) ? (string) $_GET['slug'] : '';
+$slug = strtolower($slug);
+if (!is_valid_slug($slug)) {
+    send_json(['error' => 'Tour inválido'], 400);
+}
+
+$tour = load_tour($slug);
+if ($tour === null) {
+    send_json(['error' => 'Tour no encontrado'], 404);
+}
+
+$response = format_tour_response($slug, $tour);
+$response['folderPath'] = '/tours/' . $slug;
+
+send_json($response);

--- a/public/api/save-tour.php
+++ b/public/api/save-tour.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    send_json(['error' => 'Método no permitido'], 405);
+}
+
+$slug = isset($_GET['slug']) ? (string) $_GET['slug'] : '';
+$slug = strtolower($slug);
+if (!is_valid_slug($slug)) {
+    send_json(['error' => 'Tour inválido'], 400);
+}
+ensure_slug_is_allowed($slug);
+
+$tour = load_tour($slug);
+if ($tour === null) {
+    send_json(['error' => 'Tour no encontrado'], 404);
+}
+
+$data = read_json_input();
+$title = isset($data['title']) ? trim((string) $data['title']) : '';
+$initialSceneId = isset($data['initialSceneId']) ? (string) $data['initialSceneId'] : null;
+$scenesPayload = isset($data['scenes']) && is_array($data['scenes']) ? $data['scenes'] : [];
+
+$dir = tours_dir($slug);
+$cleanScenes = [];
+foreach ($scenesPayload as $scenePayload) {
+    if (!is_array($scenePayload)) {
+        continue;
+    }
+    $clean = clean_scene($scenePayload, $dir);
+    if ($clean !== null) {
+        $cleanScenes[] = $clean;
+    }
+}
+
+if ($initialSceneId !== null) {
+    $exists = false;
+    foreach ($cleanScenes as $scene) {
+        if ($scene['id'] === $initialSceneId) {
+            $exists = true;
+            break;
+        }
+    }
+    if (!$exists) {
+        $initialSceneId = null;
+    }
+}
+
+if ($initialSceneId === null && !empty($cleanScenes)) {
+    $initialSceneId = $cleanScenes[0]['id'];
+}
+
+$tour['title'] = $title === '' ? ($tour['title'] ?? $slug) : $title;
+$tour['initialSceneId'] = $initialSceneId;
+$tour['scenes'] = $cleanScenes;
+
+save_tour($slug, $tour);
+
+send_json(format_tour_response($slug, $tour));

--- a/public/api/upload-scene.php
+++ b/public/api/upload-scene.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    send_json(['error' => 'Método no permitido'], 405);
+}
+
+$slug = isset($_GET['slug']) ? (string) $_GET['slug'] : '';
+$slug = strtolower($slug);
+if (!is_valid_slug($slug)) {
+    send_json(['error' => 'Tour inválido'], 400);
+}
+ensure_slug_is_allowed($slug);
+
+$tour = load_tour($slug);
+if ($tour === null) {
+    send_json(['error' => 'Tour no encontrado'], 404);
+}
+
+if (!isset($_FILES['scene']) || !is_uploaded_file($_FILES['scene']['tmp_name'])) {
+    send_json(['error' => 'No se recibió ningún archivo'], 400);
+}
+
+$fileInfo = $_FILES['scene'];
+$originalName = $fileInfo['name'] ?? 'escena.jpg';
+$extension = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+if (!allowed_extension($extension)) {
+    send_json(['error' => 'Formato de imagen no permitido'], 400);
+}
+
+$sceneName = isset($_POST['sceneName']) ? trim((string) $_POST['sceneName']) : '';
+if ($sceneName === '') {
+    $sceneName = preg_replace('/\.[^.]+$/', '', (string) $originalName) ?? 'Escena';
+}
+
+$sceneId = generate_scene_id();
+$filename = generate_scene_filename($extension);
+$targetDir = tours_dir($slug);
+if (!is_dir($targetDir) && !mkdir($targetDir, 0775, true) && !is_dir($targetDir)) {
+    send_json(['error' => 'No se pudo guardar la escena'], 500);
+}
+$targetPath = $targetDir . DIRECTORY_SEPARATOR . $filename;
+
+if (!move_uploaded_file($fileInfo['tmp_name'], $targetPath)) {
+    send_json(['error' => 'No se pudo guardar la escena'], 500);
+}
+
+$sceneData = [
+    'id' => $sceneId,
+    'name' => $sceneName,
+    'file' => $filename,
+    'hotspots' => [],
+];
+
+$tour['scenes'][] = $sceneData;
+if (empty($tour['initialSceneId'])) {
+    $tour['initialSceneId'] = $sceneId;
+}
+
+save_tour($slug, $tour);
+
+send_json([
+    'scene' => format_scene($slug, $sceneData),
+    'tour' => format_tour_response($slug, $tour),
+]);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tour360 Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.css"
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="hero">
+        <div>
+          <p class="hero-kicker">Crea experiencias inmersivas</p>
+          <h1>Tour360 Studio</h1>
+          <p class="hero-subtitle">
+            Construye tours 360° minimalistas en minutos. Sube tus escenas,
+            posiciona hotspots y comparte el resultado con una sola URL.
+          </p>
+        </div>
+      </header>
+
+      <section class="creation-panel" id="createPanel">
+        <form id="createTourForm" class="card">
+          <h2>Comienza un nuevo tour</h2>
+          <div class="field">
+            <label for="tourName">Nombre de la carpeta *</label>
+            <input
+              type="text"
+              id="tourName"
+              name="tourName"
+              placeholder="ej. showroom-neon"
+              autocomplete="off"
+              required
+            />
+            <small>
+              Solo letras, números y guiones. Así se verá tu enlace:
+              <span id="slugPreview">tu-dominio/carpeta</span>
+            </small>
+          </div>
+          <div class="field">
+            <label for="tourTitle">Título visible (opcional)</label>
+            <input
+              type="text"
+              id="tourTitle"
+              name="tourTitle"
+              placeholder="Nombre para tus visitantes"
+            />
+          </div>
+          <button class="primary" type="submit">Crear tour</button>
+          <p class="hint">
+            Si el tour ya existe, lo abriremos para seguir editando.
+          </p>
+        </form>
+      </section>
+
+      <section class="workspace hidden" id="workspace">
+        <aside class="sidebar">
+          <div class="sidebar-header">
+            <h2>Escenas 360°</h2>
+            <p class="muted">
+              Sube panorámicas equirectangulares en JPG, PNG o WEBP.
+            </p>
+          </div>
+          <label class="upload-label">
+            <input type="file" id="sceneUpload" accept="image/*" />
+            <span>Subir nueva escena</span>
+          </label>
+          <div class="sidebar-info">
+            <p id="tourFolderInfo"></p>
+            <a
+              id="tourPublicLink"
+              class="tour-link hidden"
+              href="#"
+              target="_blank"
+              rel="noopener"
+            ></a>
+          </div>
+          <ul class="scene-list" id="scenesList"></ul>
+        </aside>
+        <section class="viewer-area">
+          <div class="viewer-header">
+            <div>
+              <h2 id="currentSceneTitle">Selecciona una escena</h2>
+              <p id="viewerHint" class="muted"></p>
+            </div>
+            <div class="viewer-actions">
+              <button class="ghost" type="button" id="addHotspot">
+                Añadir hotspot
+              </button>
+              <button class="primary" type="button" id="saveTour">
+                Guardar tour
+              </button>
+            </div>
+          </div>
+          <div class="viewer-shell">
+            <div id="viewer" class="viewer"></div>
+            <div id="placingNotice" class="placing hidden">
+              Haz clic sobre la escena para posicionar el hotspot
+            </div>
+          </div>
+          <div class="hotspots-panel">
+            <div class="hotspots-head">
+              <h3>Hotspots de la escena</h3>
+              <span id="hotspotCount" class="muted"></span>
+            </div>
+            <ul class="hotspot-list" id="hotspotsList"></ul>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <div class="modal hidden" id="sceneModal" role="dialog" aria-modal="true">
+      <div class="modal-content">
+        <h3>Nombrar escena</h3>
+        <p class="muted" id="sceneFileName"></p>
+        <label class="field">
+          <span>Nombre</span>
+          <input type="text" id="sceneNameInput" placeholder="Vista principal" />
+        </label>
+        <div class="modal-actions">
+          <button class="ghost" type="button" id="cancelSceneModal">Cancelar</button>
+          <button class="primary" type="button" id="confirmSceneModal">Subir escena</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal hidden" id="hotspotModal" role="dialog" aria-modal="true">
+      <div class="modal-content">
+        <h3>Configurar hotspot</h3>
+        <label class="field">
+          <span>Etiqueta</span>
+          <input type="text" id="hotspotLabel" placeholder="Ej. Ir a lobby" />
+        </label>
+        <label class="field">
+          <span>Escena destino</span>
+          <select id="hotspotTarget"></select>
+        </label>
+        <div class="modal-actions">
+          <button class="ghost" type="button" id="cancelHotspot">Cancelar</button>
+          <button class="primary" type="button" id="confirmHotspot">Guardar hotspot</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/uevent@2.0.0/browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.js"></script>
+    <script src="/js/three-math-shim.js"></script>
+    <script type="module" src="/js/index.js"></script>
+  </body>
+</html>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,0 +1,609 @@
+const state = {
+  slug: '',
+  title: '',
+  scenes: [],
+  initialSceneId: null,
+  currentSceneId: null,
+};
+
+let viewer = null;
+let markersPlugin = null;
+let placingHotspot = false;
+let pendingCoords = null;
+let pendingSceneFile = null;
+let toastTimeout = null;
+
+const createForm = document.getElementById('createTourForm');
+const createPanel = document.getElementById('createPanel');
+const workspace = document.getElementById('workspace');
+const tourNameInput = document.getElementById('tourName');
+const tourTitleInput = document.getElementById('tourTitle');
+const slugPreview = document.getElementById('slugPreview');
+const sceneUploadInput = document.getElementById('sceneUpload');
+const scenesListEl = document.getElementById('scenesList');
+const viewerTitleEl = document.getElementById('currentSceneTitle');
+const viewerHintEl = document.getElementById('viewerHint');
+const addHotspotBtn = document.getElementById('addHotspot');
+const saveTourBtn = document.getElementById('saveTour');
+const hotspotsListEl = document.getElementById('hotspotsList');
+const hotspotCountEl = document.getElementById('hotspotCount');
+const placingNotice = document.getElementById('placingNotice');
+const hotspotModal = document.getElementById('hotspotModal');
+const hotspotLabelInput = document.getElementById('hotspotLabel');
+const hotspotTargetSelect = document.getElementById('hotspotTarget');
+const confirmHotspotBtn = document.getElementById('confirmHotspot');
+const cancelHotspotBtn = document.getElementById('cancelHotspot');
+const toastEl = document.getElementById('toast');
+const tourFolderInfo = document.getElementById('tourFolderInfo');
+const tourPublicLink = document.getElementById('tourPublicLink');
+const sceneModal = document.getElementById('sceneModal');
+const sceneNameInput = document.getElementById('sceneNameInput');
+const confirmSceneModalBtn = document.getElementById('confirmSceneModal');
+const cancelSceneModalBtn = document.getElementById('cancelSceneModal');
+const sceneFileName = document.getElementById('sceneFileName');
+
+function normalizeOrigin() {
+  return window.location.origin && window.location.origin !== 'null'
+    ? window.location.origin
+    : 'tu-dominio';
+}
+
+function slugify(value) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-\s]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function updateSlugPreview() {
+  const slug = slugify(tourNameInput.value) || 'carpeta';
+  slugPreview.textContent = `${normalizeOrigin()}/${slug}`;
+}
+
+tourNameInput.addEventListener('input', updateSlugPreview);
+
+function showToast(message, type = 'info') {
+  toastEl.textContent = message;
+  toastEl.classList.remove('hidden', 'success', 'error', 'visible');
+  if (type === 'success') {
+    toastEl.classList.add('success');
+  } else if (type === 'error') {
+    toastEl.classList.add('error');
+  }
+  toastEl.classList.add('visible');
+  clearTimeout(toastTimeout);
+  toastTimeout = setTimeout(() => {
+    toastEl.classList.add('hidden');
+    toastEl.classList.remove('visible');
+  }, 3200);
+}
+
+function hideToast() {
+  toastEl.classList.add('hidden');
+  toastEl.classList.remove('visible');
+  clearTimeout(toastTimeout);
+}
+
+function mapScene(scene) {
+  return {
+    id: scene.id,
+    name: scene.name,
+    file: scene.file,
+    hotspots: (scene.hotspots || []).map((spot) => ({
+      id: spot.id,
+      label: spot.label,
+      targetSceneId: spot.targetSceneId || null,
+      yaw: Number(spot.yaw),
+      pitch: Number(spot.pitch),
+    })),
+    url: scene.url || `/tours/${state.slug}/${scene.file}`,
+  };
+}
+
+function getSceneById(id) {
+  return state.scenes.find((scene) => scene.id === id) || null;
+}
+
+function getCurrentScene() {
+  return getSceneById(state.currentSceneId);
+}
+
+function renderScenesList() {
+  if (!state.scenes.length) {
+    scenesListEl.innerHTML = '<li class="scene-empty">Sube tu primera escena 360° para comenzar.</li>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  state.scenes.forEach((scene) => {
+    const li = document.createElement('li');
+    li.className = `scene-item${state.currentSceneId === scene.id ? ' active' : ''}`;
+    li.dataset.id = scene.id;
+
+    const img = document.createElement('img');
+    img.src = scene.url;
+    img.alt = scene.name;
+    img.className = 'scene-thumb';
+    li.appendChild(img);
+
+    const details = document.createElement('div');
+    details.className = 'scene-details';
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'scene-name';
+    nameEl.textContent = scene.name;
+    details.appendChild(nameEl);
+
+    const actions = document.createElement('div');
+    actions.className = 'scene-actions';
+
+    const viewBtn = document.createElement('button');
+    viewBtn.type = 'button';
+    viewBtn.dataset.action = 'view';
+    viewBtn.className = 'ghost';
+    viewBtn.textContent = 'Ver escena';
+    actions.appendChild(viewBtn);
+
+    const initialBtn = document.createElement('button');
+    initialBtn.type = 'button';
+    initialBtn.dataset.action = 'initial';
+    initialBtn.className = 'ghost';
+    if (state.initialSceneId === scene.id) {
+      initialBtn.classList.add('is-initial');
+      initialBtn.textContent = 'Inicio actual';
+    } else {
+      initialBtn.textContent = 'Marcar inicio';
+    }
+    actions.appendChild(initialBtn);
+
+    details.appendChild(actions);
+    li.appendChild(details);
+    fragment.appendChild(li);
+  });
+
+  scenesListEl.innerHTML = '';
+  scenesListEl.appendChild(fragment);
+}
+
+function renderHotspotList(scene) {
+  hotspotsListEl.innerHTML = '';
+  if (!scene || !scene.hotspots.length) {
+    const empty = document.createElement('li');
+    empty.className = 'scene-empty';
+    empty.textContent = 'No hay hotspots en esta escena todavía.';
+    hotspotsListEl.appendChild(empty);
+    hotspotCountEl.textContent = '0 hotspots';
+    return;
+  }
+
+  hotspotCountEl.textContent = `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'}`;
+
+  const fragment = document.createDocumentFragment();
+  scene.hotspots.forEach((hotspot) => {
+    const item = document.createElement('li');
+    item.className = 'hotspot-item';
+    item.dataset.id = hotspot.id;
+
+    const meta = document.createElement('div');
+    meta.className = 'hotspot-meta';
+    const label = document.createElement('strong');
+    label.textContent = hotspot.label;
+    const targetScene = getSceneById(hotspot.targetSceneId);
+    const hint = document.createElement('span');
+    hint.textContent = targetScene ? `Dirige a: ${targetScene.name}` : 'Sin escena destino';
+    meta.appendChild(label);
+    meta.appendChild(hint);
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'danger';
+    remove.dataset.id = hotspot.id;
+    remove.textContent = 'Eliminar';
+
+    item.appendChild(meta);
+    item.appendChild(remove);
+    fragment.appendChild(item);
+  });
+  hotspotsListEl.appendChild(fragment);
+}
+
+function updateViewerMarkers(scene) {
+  if (!markersPlugin) return;
+  markersPlugin.clearMarkers();
+  (scene.hotspots || []).forEach((hotspot) => {
+    const target = getSceneById(hotspot.targetSceneId);
+    const tooltip = target
+      ? `<strong>${escapeHtml(hotspot.label)}</strong><br/><span>${escapeHtml(target.name)}</span>`
+      : `<strong>${escapeHtml(hotspot.label)}</strong>`;
+    markersPlugin.addMarker({
+      id: hotspot.id,
+      longitude: hotspot.yaw,
+      latitude: hotspot.pitch,
+      html: '<div class="hotspot-pin"></div>',
+      anchor: 'bottom center',
+      tooltip: { content: tooltip },
+      data: { targetSceneId: hotspot.targetSceneId },
+    });
+  });
+}
+
+function escapeHtml(text = '') {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function ensureViewer(scene) {
+  if (viewer) {
+    viewer.setPanorama(scene.url);
+    return;
+  }
+
+  viewer = new PhotoSphereViewer.Viewer({
+    container: document.getElementById('viewer'),
+    panorama: scene.url,
+    navbar: ['zoomOut', 'zoomRange', 'zoomIn', 'fullscreen'],
+    touchmoveTwoFingers: true,
+    plugins: [[PhotoSphereViewer.MarkersPlugin, { markers: [] }]],
+  });
+
+  markersPlugin = viewer.getPlugin(PhotoSphereViewer.MarkersPlugin);
+
+  viewer.on('panorama-loaded', () => {
+    const current = getCurrentScene();
+    if (current) {
+      viewerTitleEl.textContent = current.name;
+      viewerHintEl.textContent = current.hotspots.length
+        ? `${current.hotspots.length} hotspot${current.hotspots.length === 1 ? '' : 's'} listos`
+        : 'Aún no hay hotspots en esta escena';
+      updateViewerMarkers(current);
+    }
+  });
+
+  viewer.on('click', (_event, data) => {
+    if (!placingHotspot) return;
+    placingHotspot = false;
+    placingNotice.classList.add('hidden');
+    pendingCoords = {
+      yaw: data.longitude,
+      pitch: data.latitude,
+    };
+    openHotspotModal();
+  });
+
+  markersPlugin.on('select-marker', (_event, marker) => {
+    const targetId = marker?.config?.data?.targetSceneId
+      ?? marker?.data?.targetSceneId
+      ?? null;
+    if (targetId) {
+      activateScene(targetId);
+    }
+  });
+}
+
+function activateScene(sceneId) {
+  const scene = getSceneById(sceneId);
+  if (!scene) return;
+  state.currentSceneId = sceneId;
+  ensureViewer(scene);
+  viewer.setPanorama(scene.url);
+  viewerTitleEl.textContent = scene.name;
+  viewerHintEl.textContent = scene.hotspots.length
+    ? `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'} listos`
+    : 'Aún no hay hotspots en esta escena';
+  renderScenesList();
+  renderHotspotList(scene);
+  hotspotCountEl.textContent = `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'}`;
+}
+
+function resetSceneUpload() {
+  pendingSceneFile = null;
+  sceneNameInput.value = '';
+  sceneModal.classList.add('hidden');
+  confirmSceneModalBtn.disabled = false;
+}
+
+function openSceneModal(file, suggestedName) {
+  pendingSceneFile = file;
+  sceneFileName.textContent = file.name;
+  sceneNameInput.value = suggestedName;
+  sceneModal.classList.remove('hidden');
+  sceneNameInput.focus();
+}
+
+function openHotspotModal() {
+  hotspotModal.classList.remove('hidden');
+  hotspotLabelInput.value = '';
+  hotspotLabelInput.focus();
+  hotspotTargetSelect.innerHTML = '';
+
+  const fragment = document.createDocumentFragment();
+  state.scenes.forEach((scene) => {
+    const option = document.createElement('option');
+    option.value = scene.id;
+    option.textContent = scene.name;
+    if (scene.id === state.currentSceneId) {
+      option.selected = true;
+    }
+    fragment.appendChild(option);
+  });
+  hotspotTargetSelect.appendChild(fragment);
+}
+
+function closeHotspotModal() {
+  hotspotModal.classList.add('hidden');
+  hotspotLabelInput.value = '';
+  hotspotTargetSelect.innerHTML = '';
+  pendingCoords = null;
+}
+
+function startHotspotPlacement() {
+  const current = getCurrentScene();
+  if (!current) {
+    showToast('Primero selecciona una escena', 'error');
+    return;
+  }
+  placingHotspot = true;
+  pendingCoords = null;
+  placingNotice.classList.remove('hidden');
+  showToast('Haz clic en la escena para colocar el hotspot');
+}
+
+async function uploadScene(name) {
+  if (!pendingSceneFile) return;
+  confirmSceneModalBtn.disabled = true;
+  const formData = new FormData();
+  formData.append('scene', pendingSceneFile);
+  formData.append('sceneName', name);
+
+  try {
+    const response = await fetch(`/api/upload-scene.php?slug=${encodeURIComponent(state.slug)}`, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      showToast(error.error || 'No se pudo subir la escena', 'error');
+      resetSceneUpload();
+      return;
+    }
+    const data = await response.json();
+    const newScene = mapScene(data.scene);
+    state.scenes.push(newScene);
+    state.initialSceneId = data.tour.initialSceneId || state.initialSceneId;
+    renderScenesList();
+    if (!state.currentSceneId) {
+      activateScene(newScene.id);
+    }
+    showToast('Escena subida correctamente', 'success');
+  } catch (error) {
+    console.error(error);
+    showToast('Error al subir la escena', 'error');
+  } finally {
+    resetSceneUpload();
+  }
+}
+
+async function saveTour() {
+  if (!state.slug) return;
+  saveTourBtn.disabled = true;
+  const payload = {
+    title: state.title,
+    initialSceneId: state.initialSceneId,
+    scenes: state.scenes.map((scene) => ({
+      id: scene.id,
+      name: scene.name,
+      file: scene.file,
+      hotspots: scene.hotspots.map((spot) => ({
+        id: spot.id,
+        label: spot.label,
+        targetSceneId: spot.targetSceneId,
+        yaw: spot.yaw,
+        pitch: spot.pitch,
+      })),
+    })),
+  };
+
+  try {
+    const response = await fetch(`/api/save-tour.php?slug=${encodeURIComponent(state.slug)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      showToast(error.error || 'No se pudo guardar el tour', 'error');
+      return;
+    }
+    const data = await response.json();
+    state.title = data.title;
+    state.initialSceneId = data.initialSceneId;
+    state.scenes = data.scenes.map(mapScene);
+    if (state.currentSceneId) {
+      const refreshed = getSceneById(state.currentSceneId);
+      if (refreshed) {
+        renderHotspotList(refreshed);
+        updateViewerMarkers(refreshed);
+      }
+    }
+    renderScenesList();
+    showToast('Tour guardado', 'success');
+  } catch (error) {
+    console.error(error);
+    showToast('Error de conexión al guardar', 'error');
+  } finally {
+    saveTourBtn.disabled = false;
+  }
+}
+
+createForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const name = tourNameInput.value.trim();
+  const title = tourTitleInput.value.trim();
+  if (!name) {
+    showToast('Escribe un nombre para tu tour', 'error');
+    return;
+  }
+  const payload = { name, title };
+  try {
+    const response = await fetch('/api/create-tour.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      showToast(data.error || 'No se pudo crear el tour', 'error');
+      return;
+    }
+    state.slug = data.slug;
+    state.title = data.title;
+    state.initialSceneId = data.initialSceneId;
+    state.scenes = (data.scenes || []).map(mapScene);
+    createPanel.classList.add('hidden');
+    workspace.classList.remove('hidden');
+    tourFolderInfo.textContent = `Carpeta actual: /${state.slug}`;
+    tourPublicLink.href = `/${state.slug}`;
+    tourPublicLink.textContent = `${normalizeOrigin()}/${state.slug}`;
+    tourPublicLink.classList.remove('hidden');
+    renderScenesList();
+    if (state.initialSceneId) {
+      activateScene(state.initialSceneId);
+    }
+    showToast('Tour listo para editar', 'success');
+  } catch (error) {
+    console.error(error);
+    showToast('No se pudo conectar con el servidor', 'error');
+  }
+});
+
+sceneUploadInput.addEventListener('change', (event) => {
+  if (!state.slug) {
+    showToast('Crea un tour antes de subir escenas', 'error');
+    sceneUploadInput.value = '';
+    return;
+  }
+  const file = event.target.files && event.target.files[0];
+  if (!file) return;
+  const suggested = file.name.replace(/\.[^.]+$/, '').replace(/[_-]+/g, ' ');
+  openSceneModal(file, suggested);
+  sceneUploadInput.value = '';
+});
+
+confirmSceneModalBtn.addEventListener('click', () => {
+  if (!pendingSceneFile) return;
+  const sceneName = sceneNameInput.value.trim() || pendingSceneFile.name.replace(/\.[^.]+$/, '');
+  uploadScene(sceneName);
+});
+
+cancelSceneModalBtn.addEventListener('click', resetSceneUpload);
+
+sceneModal.addEventListener('click', (event) => {
+  if (event.target === sceneModal) {
+    resetSceneUpload();
+  }
+});
+
+confirmHotspotBtn.addEventListener('click', () => {
+  const scene = getCurrentScene();
+  if (!scene || !pendingCoords) {
+    closeHotspotModal();
+    return;
+  }
+  const label = hotspotLabelInput.value.trim();
+  const targetSceneId = hotspotTargetSelect.value;
+  if (!label) {
+    showToast('Escribe una etiqueta para el hotspot', 'error');
+    return;
+  }
+  if (!targetSceneId) {
+    showToast('Elige una escena destino', 'error');
+    return;
+  }
+  const hotspot = {
+    id: `hotspot-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`,
+    label,
+    targetSceneId,
+    yaw: pendingCoords.yaw,
+    pitch: pendingCoords.pitch,
+  };
+  scene.hotspots.push(hotspot);
+  closeHotspotModal();
+  renderHotspotList(scene);
+  updateViewerMarkers(scene);
+  showToast('Hotspot agregado', 'success');
+});
+
+cancelHotspotBtn.addEventListener('click', () => {
+  closeHotspotModal();
+});
+
+hotspotModal.addEventListener('click', (event) => {
+  if (event.target === hotspotModal) {
+    closeHotspotModal();
+  }
+});
+
+hotspotsListEl.addEventListener('click', (event) => {
+  const button = event.target.closest('button[data-id]');
+  if (!button) return;
+  const scene = getCurrentScene();
+  if (!scene) return;
+  const hotspotId = button.dataset.id;
+  scene.hotspots = scene.hotspots.filter((spot) => spot.id !== hotspotId);
+  renderHotspotList(scene);
+  updateViewerMarkers(scene);
+  showToast('Hotspot eliminado', 'success');
+});
+
+scenesListEl.addEventListener('click', (event) => {
+  const actionButton = event.target.closest('button[data-action]');
+  if (!actionButton) return;
+  const item = actionButton.closest('li[data-id]');
+  if (!item) return;
+  const sceneId = item.dataset.id;
+
+  if (actionButton.dataset.action === 'view') {
+    activateScene(sceneId);
+  } else if (actionButton.dataset.action === 'initial') {
+    state.initialSceneId = sceneId;
+    renderScenesList();
+    showToast('Escena marcada como inicio', 'success');
+  }
+});
+
+addHotspotBtn.addEventListener('click', () => {
+  startHotspotPlacement();
+});
+
+saveTourBtn.addEventListener('click', () => {
+  saveTour();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    if (!sceneModal.classList.contains('hidden')) {
+      resetSceneUpload();
+    }
+    if (!hotspotModal.classList.contains('hidden')) {
+      closeHotspotModal();
+    }
+    if (placingHotspot) {
+      placingHotspot = false;
+      placingNotice.classList.add('hidden');
+      pendingCoords = null;
+    }
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  hideToast();
+});
+
+updateSlugPreview();

--- a/public/js/three-math-shim.js
+++ b/public/js/three-math-shim.js
@@ -1,0 +1,5 @@
+(function ensureThreeMathCompat() {
+  if (window.THREE && !window.THREE.Math && window.THREE.MathUtils) {
+    window.THREE.Math = window.THREE.MathUtils;
+  }
+})();

--- a/public/js/viewer.js
+++ b/public/js/viewer.js
@@ -1,0 +1,186 @@
+const viewerContainer = document.getElementById('viewer');
+const tourTitleEl = document.getElementById('tourTitle');
+const tourSubtitleEl = document.getElementById('tourSubtitle');
+const tourPathEl = document.getElementById('tourPath');
+const sceneSelect = document.getElementById('sceneSelect');
+const messageEl = document.getElementById('viewerMessage');
+
+let viewer = null;
+let markersPlugin = null;
+let scenes = [];
+let currentSceneId = null;
+
+function normalizeOrigin() {
+  return window.location.origin && window.location.origin !== 'null'
+    ? window.location.origin
+    : 'tu-dominio';
+}
+
+function escapeHtml(text = '') {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function mapScene(slug, scene) {
+  return {
+    id: scene.id,
+    name: scene.name,
+    file: scene.file,
+    hotspots: (scene.hotspots || []).map((spot) => ({
+      id: spot.id,
+      label: spot.label,
+      targetSceneId: spot.targetSceneId,
+      yaw: Number(spot.yaw),
+      pitch: Number(spot.pitch),
+    })),
+    url: scene.url || `/tours/${slug}/${scene.file}`,
+  };
+}
+
+function showMessage(text) {
+  messageEl.textContent = text;
+  messageEl.classList.remove('hidden');
+}
+
+function hideMessage() {
+  messageEl.classList.add('hidden');
+}
+
+function updateSceneOptions() {
+  sceneSelect.innerHTML = '';
+  if (!scenes.length) {
+    sceneSelect.disabled = true;
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  scenes.forEach((scene) => {
+    const option = document.createElement('option');
+    option.value = scene.id;
+    option.textContent = scene.name;
+    if (scene.id === currentSceneId) {
+      option.selected = true;
+    }
+    fragment.appendChild(option);
+  });
+  sceneSelect.appendChild(fragment);
+  sceneSelect.disabled = scenes.length <= 1;
+}
+
+function renderMarkers(scene) {
+  if (!markersPlugin) return;
+  markersPlugin.clearMarkers();
+  scene.hotspots.forEach((hotspot) => {
+    const target = scenes.find((item) => item.id === hotspot.targetSceneId);
+    const tooltip = target
+      ? `<strong>${escapeHtml(hotspot.label)}</strong><br/><span>${escapeHtml(target.name)}</span>`
+      : `<strong>${escapeHtml(hotspot.label)}</strong>`;
+    markersPlugin.addMarker({
+      id: hotspot.id,
+      longitude: Number(hotspot.yaw),
+      latitude: Number(hotspot.pitch),
+      html: '<div class="hotspot-pin"></div>',
+      anchor: 'bottom center',
+      tooltip: { content: tooltip },
+      data: { targetSceneId: hotspot.targetSceneId },
+    });
+  });
+}
+
+function updateSceneInfo(scene) {
+  tourSubtitleEl.textContent = scene.hotspots.length
+    ? `${scene.hotspots.length} hotspot${scene.hotspots.length === 1 ? '' : 's'} interactivo${scene.hotspots.length === 1 ? '' : 's'}`
+    : 'Esta escena aún no tiene hotspots.';
+}
+
+function setScene(sceneId) {
+  if (!viewer) return;
+  if (sceneId === currentSceneId) {
+    return;
+  }
+  const scene = scenes.find((item) => item.id === sceneId);
+  if (!scene) return;
+  currentSceneId = sceneId;
+  viewer.setPanorama(scene.url);
+  updateSceneOptions();
+  updateSceneInfo(scene);
+}
+
+function initializeViewer(initialScene) {
+  viewer = new PhotoSphereViewer.Viewer({
+    container: viewerContainer,
+    panorama: initialScene.url,
+    navbar: ['zoomOut', 'zoomRange', 'zoomIn', 'fullscreen'],
+    touchmoveTwoFingers: true,
+    plugins: [[PhotoSphereViewer.MarkersPlugin, { markers: [] }]],
+  });
+  markersPlugin = viewer.getPlugin(PhotoSphereViewer.MarkersPlugin);
+
+  viewer.on('panorama-loaded', () => {
+    const scene = scenes.find((item) => item.id === currentSceneId);
+    if (scene) {
+      renderMarkers(scene);
+      updateSceneInfo(scene);
+    }
+  });
+
+  markersPlugin.on('select-marker', (_event, marker) => {
+    const targetId = marker?.config?.data?.targetSceneId
+      ?? marker?.data?.targetSceneId
+      ?? null;
+    if (targetId) {
+      setScene(targetId);
+      sceneSelect.value = targetId;
+    }
+  });
+}
+
+async function loadTour(slug) {
+  tourPathEl.textContent = `${normalizeOrigin()}/${slug}`;
+  try {
+    const response = await fetch(`/api/get-tour.php?slug=${encodeURIComponent(slug)}`);
+    if (!response.ok) {
+      showMessage('No pudimos encontrar este tour.');
+      return;
+    }
+    const data = await response.json();
+    scenes = (data.scenes || []).map((scene) => mapScene(slug, scene));
+    tourTitleEl.textContent = data.title || slug;
+    if (!scenes.length) {
+      showMessage('Este tour aún no tiene escenas publicadas.');
+      return;
+    }
+    hideMessage();
+    const initialScene = scenes.find((scene) => scene.id === data.initialSceneId) || scenes[0];
+    currentSceneId = initialScene.id;
+    updateSceneOptions();
+    initializeViewer(initialScene);
+    updateSceneInfo(initialScene);
+    sceneSelect.value = currentSceneId;
+  } catch (error) {
+    console.error(error);
+    showMessage('Ha ocurrido un error al cargar el tour.');
+  }
+}
+
+sceneSelect.addEventListener('change', (event) => {
+  setScene(event.target.value);
+});
+
+const providedSlug = typeof window !== 'undefined' ? window.__TOUR_SLUG__ : '';
+const pathSegments = window.location.pathname.split('/').filter(Boolean);
+let slug = '';
+
+if (providedSlug) {
+  slug = decodeURIComponent(providedSlug);
+} else if (pathSegments.length >= 2 && pathSegments[0] === 'tours') {
+  slug = decodeURIComponent(pathSegments[1]);
+} else if (pathSegments.length >= 1) {
+  slug = decodeURIComponent(pathSegments[0]);
+}
+
+if (!slug) {
+  showMessage('Para ver un tour ingresa con la ruta /tu-carpeta.');
+} else {
+  loadTour(slug);
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,567 @@
+:root {
+  --bg: #050714;
+  --bg-alt: #090c1f;
+  --panel: #11162c;
+  --panel-alt: rgba(40, 58, 112, 0.35);
+  --text: #f6f7ff;
+  --muted: #8da2d6;
+  --accent: #4f9cff;
+  --accent-secondary: #9b5cff;
+  --danger: #ff5f7d;
+  --success: #4cd2b1;
+  --border: rgba(118, 144, 212, 0.25);
+  --shadow: 0 24px 48px rgba(10, 14, 35, 0.55);
+  font-family: "Outfit", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(79, 156, 255, 0.15), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(155, 92, 255, 0.12), transparent 40%),
+    var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  display: flex;
+  justify-content: center;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  width: min(1200px, 96vw);
+  padding: 3.5rem 0 4rem;
+}
+
+.hero {
+  margin-bottom: 2rem;
+  background: linear-gradient(135deg, rgba(79, 156, 255, 0.2), rgba(155, 92, 255, 0.08));
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2.5rem 3rem;
+  box-shadow: var(--shadow);
+}
+
+.hero-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.76rem;
+  color: var(--muted);
+  margin: 0 0 0.75rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  font-weight: 600;
+}
+
+.hero-subtitle {
+  margin: 1rem 0 0;
+  color: var(--muted);
+  max-width: 48rem;
+  line-height: 1.6;
+}
+
+.creation-panel {
+  margin-bottom: 2.5rem;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2rem 2.5rem;
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.card h2 {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.6rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.field label,
+.field span {
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+input,
+select {
+  background: rgba(12, 17, 36, 0.85);
+  border: 1px solid rgba(118, 144, 212, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  color: var(--text);
+  font: inherit;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(79, 156, 255, 0.22);
+}
+
+small {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 1.3rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+  color: var(--text);
+  box-shadow: 0 12px 24px rgba(79, 156, 255, 0.35);
+}
+
+button.primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+button.ghost {
+  background: rgba(79, 156, 255, 0.08);
+  color: var(--text);
+  border: 1px solid rgba(79, 156, 255, 0.3);
+}
+
+button.ghost:hover:not(:disabled) {
+  background: rgba(79, 156, 255, 0.18);
+}
+
+button.danger {
+  background: rgba(255, 95, 125, 0.18);
+  border: 1px solid rgba(255, 95, 125, 0.45);
+  color: var(--text);
+}
+
+button.danger:hover:not(:disabled) {
+  background: rgba(255, 95, 125, 0.28);
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--muted);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 2rem;
+}
+
+.sidebar {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.75rem 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  height: fit-content;
+}
+
+.sidebar-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.sidebar-info {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.upload-label {
+  display: grid;
+  place-items: center;
+  padding: 1.2rem;
+  border-radius: 16px;
+  background: rgba(79, 156, 255, 0.08);
+  border: 1px dashed rgba(79, 156, 255, 0.35);
+  color: var(--accent);
+  font-weight: 500;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.upload-label:hover {
+  background: rgba(79, 156, 255, 0.15);
+}
+
+.upload-label input {
+  display: none;
+}
+
+.tour-link {
+  font-size: 0.85rem;
+  color: var(--accent);
+  word-break: break-all;
+}
+
+.scene-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.scene-item {
+  background: rgba(17, 25, 46, 0.85);
+  border: 1px solid rgba(79, 156, 255, 0.18);
+  border-radius: 16px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 1rem;
+  padding: 0.75rem;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.scene-item.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(79, 156, 255, 0.35);
+}
+
+.scene-thumb {
+  width: 96px;
+  height: 96px;
+  border-radius: 12px;
+  object-fit: cover;
+  background: rgba(15, 20, 35, 0.75);
+}
+
+.scene-details {
+  display: grid;
+  gap: 0.55rem;
+  align-content: center;
+}
+
+.scene-name {
+  font-weight: 500;
+}
+
+.scene-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.scene-actions button {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+}
+
+.scene-actions .is-initial {
+  background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+  border: none;
+  box-shadow: 0 8px 16px rgba(79, 156, 255, 0.3);
+}
+
+.scene-empty {
+  padding: 1.5rem;
+  text-align: center;
+  border-radius: 16px;
+  border: 1px dashed rgba(79, 156, 255, 0.2);
+  color: var(--muted);
+}
+
+.viewer-area {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.viewer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.viewer-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.viewer-shell {
+  position: relative;
+  border-radius: 22px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--panel-alt);
+  box-shadow: var(--shadow);
+}
+
+.viewer {
+  width: 100%;
+  height: clamp(320px, 55vh, 520px);
+  background: radial-gradient(circle, rgba(79, 156, 255, 0.08), transparent 70%);
+}
+
+.placing {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(9, 12, 31, 0.78);
+  pointer-events: none;
+}
+
+.hotspots-panel {
+  background: rgba(17, 23, 43, 0.78);
+  border-radius: 20px;
+  border: 1px solid rgba(79, 156, 255, 0.15);
+  padding: 1.3rem 1.5rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.hotspots-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.hotspot-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hotspot-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(19, 27, 48, 0.85);
+  border: 1px solid rgba(79, 156, 255, 0.18);
+}
+
+.hotspot-meta {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hotspot-meta span {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.hotspot-item button {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 6, 18, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.modal-content {
+  background: linear-gradient(145deg, rgba(17, 23, 42, 0.95), rgba(9, 13, 28, 0.95));
+  border: 1px solid rgba(79, 156, 255, 0.25);
+  border-radius: 20px;
+  padding: 2rem 2.2rem;
+  width: min(420px, 90vw);
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(17, 23, 42, 0.95);
+  padding: 1rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 156, 255, 0.35);
+  min-width: 240px;
+  text-align: center;
+  box-shadow: var(--shadow);
+  z-index: 30;
+}
+
+.toast.success {
+  border-color: rgba(76, 210, 177, 0.5);
+  color: var(--success);
+}
+
+.toast.error {
+  border-color: rgba(255, 95, 125, 0.55);
+  color: var(--danger);
+}
+
+.viewer-body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% -10%, rgba(155, 92, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 90% 10%, rgba(79, 156, 255, 0.15), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+}
+
+.viewer-app {
+  width: min(1200px, 96vw);
+  padding: 2.5rem 0 3rem;
+  display: grid;
+  gap: 1.8rem;
+}
+
+.viewer-bar {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem 2.5rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-end;
+}
+
+.viewer-controls {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.viewer-controls select {
+  min-width: 200px;
+}
+
+.viewer-stage {
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  background: var(--panel-alt);
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.viewer-message {
+  margin-top: 1rem;
+  background: rgba(19, 27, 48, 0.9);
+  border: 1px solid rgba(79, 156, 255, 0.25);
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.psv-marker svg,
+.psv-marker .hotspot-pin {
+  width: 22px;
+  height: 22px;
+}
+
+.psv-marker .hotspot-pin {
+  background: radial-gradient(circle, var(--accent) 0%, rgba(79, 156, 255, 0.4) 70%, transparent 100%);
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 18px rgba(79, 156, 255, 0.65);
+}
+
+@media (max-width: 1024px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .viewer-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .viewer-controls {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  main,
+  .viewer-app {
+    width: 92vw;
+  }
+
+  .hero,
+  .viewer-bar,
+  .viewer-stage,
+  .card,
+  .sidebar,
+  .hotspots-panel {
+    padding: 1.4rem 1.5rem;
+  }
+
+  .scene-item {
+    grid-template-columns: 72px 1fr;
+  }
+
+  .scene-thumb {
+    width: 72px;
+    height: 72px;
+  }
+}

--- a/public/tours/.gitignore
+++ b/public/tours/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/public/viewer.php
+++ b/public/viewer.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+$slug = isset($_GET['slug']) ? (string) $_GET['slug'] : '';
+$slugAttr = htmlspecialchars($slug, ENT_QUOTES, 'UTF-8');
+?>
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Explorar tour 360</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.css"
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="viewer-body">
+    <main class="viewer-app">
+      <header class="viewer-bar">
+        <div class="viewer-texts">
+          <p class="hero-kicker" id="tourPath"></p>
+          <h1 id="tourTitle">Cargando tour...</h1>
+          <p class="hero-subtitle" id="tourSubtitle">
+            Recorre el espacio con los hotspots interactivos.
+          </p>
+        </div>
+        <div class="viewer-controls">
+          <label for="sceneSelect">Escena</label>
+          <select id="sceneSelect" disabled></select>
+        </div>
+      </header>
+      <section class="viewer-stage">
+        <div id="viewer" class="viewer"></div>
+        <div id="viewerMessage" class="viewer-message hidden"></div>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/uevent@2.0.0/browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/photo-sphere-viewer.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.0.6/dist/plugins/markers.min.js"></script>
+    <script src="/js/three-math-shim.js"></script>
+    <script>window.__TOUR_SLUG__ = '<?= $slugAttr ?>';</script>
+    <script type="module" src="/js/viewer.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the Python server with a PHP API that creates tour folders, stores metadata and handles uploads inside `public/tours`
- add Apache rewrite rules and a PHP viewer entry point so `/carpeta` URLs load the existing viewer with the resolved slug
- update the builder and viewer JavaScript plus documentation to target the new endpoints and describe the Plesk deployment flow

## Testing
- php -l public/api/bootstrap.php
- php -l public/api/create-tour.php
- php -l public/api/upload-scene.php
- php -l public/api/save-tour.php
- php -l public/api/get-tour.php
- php -l public/viewer.php

------
https://chatgpt.com/codex/tasks/task_e_68c939ee7e388330b1d171cc5dede0ef